### PR TITLE
Allow css to be passed as string

### DIFF
--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -100,6 +100,7 @@ class Premailer
   # [+base_url+] Used to calculate absolute URLs for local files.
   # [+css+] Manually specify a CSS stylesheet.
   # [+css_to_attributes+] Copy related CSS attributes into HTML attributes (e.g. +background-color+ to +bgcolor+)
+  # [+css_string+] Pass CSS as a string
   # [+preserve_styles+] Whether to preserve any <tt>link rel=stylesheet</tt> and <tt>style</tt> elements.  Default is +false+.
   # [+with_html_string+] Whether the +html+ param should be treated as a raw string.
   # [+verbose+] Whether to print errors and warnings to <tt>$stderr</tt>.  Default is +false+.
@@ -112,6 +113,7 @@ class Premailer
                 :css => [],
                 :css_to_attributes => true,
                 :with_html_string => false,
+                :css_string => nil,
                 :preserve_styles => false,
                 :verbose => false,
                 :debug => false,
@@ -306,11 +308,17 @@ protected
           css_block << line
         end
       end
-      @css_parser.add_block!(css_block, {:base_uri => @base_url, :base_dir => @base_dir})
+      load_css_from_string(css_block)
     rescue; end
   end
 
+  def load_css_from_string(css_string)
+    @css_parser.add_block!(css_string, {:base_uri => @base_url, :base_dir => @base_dir})
+  end
+
   def load_css_from_options! # :nodoc:
+    load_css_from_string(@options[:css_string]) if @options[:css_string]
+
     @css_files.each do |css_file|
       if Premailer.local_data?(css_file)
         load_css_from_local_file!(css_file)

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -74,6 +74,19 @@ END_HTML
     assert_match /display: none/, @doc.at('#hide01').attributes['style']
   end
 
+  def test_importing_css_as_string
+    files_base = File.expand_path(File.dirname(__FILE__)) + '/files/'
+
+    css_string = IO.read(File.join(files_base, 'import.css'))
+
+    premailer = Premailer.new(File.join(files_base, 'no_css.html'), {:css_string => css_string})
+    premailer.to_inline_css
+    @doc = premailer.processed_doc
+
+    # import.css sets .hide to { display: none }
+    assert_match /display: none/, @doc.at('#hide01').attributes['style']
+  end
+
   def test_local_remote_check
     assert Premailer.local_data?( StringIO.new('a') )
     assert Premailer.local_data?( '/path/' )


### PR DESCRIPTION
Hi Alex,

I added a bit of code to allow premailer to load CSS from strings. It's unfortunate that the API is different for specifying CSS and HTML strings (one, you pass a boolean indicated you passed in a string; with CSS, you pass in the string directly), but this seemed the best solution given the current API.

Allowing the CSS to be passed as a string is useful for web applications where CSS/HTML are in the database or built in code; at Bust Out, we're currently using an old version that just took html & css as string arguments.

I added a test, which passes.

Unfortunately, I am getting two test failures in the premailer head (before I made any changes), line 64 & 74 in premailer_test.rb. I looked at them but I'm not sure what's going on. Apparently you're not getting failures?

Thanks a ton for premailer -- it's terribly useful!

David
