### PR TITLE
Bugfix

### DIFF
--- a/lib/premailer/adapter/hpricot.rb
+++ b/lib/premailer/adapter/hpricot.rb
@@ -38,7 +38,7 @@ module Adapter
               el['style'] = (el.attributes['style'].to_s ||= '') + ' ' + block
             end
           end
-        rescue Hpricot::Error, RuntimeError, ArgumentError
+        rescue ::Hpricot::Error, RuntimeError, ArgumentError
           $stderr.puts "CSS syntax error with selector: #{selector}" if @options[:verbose]
           next
         end


### PR DESCRIPTION
in lib/premailer/adapter/hpricot.rb on line 41
rescue was expecting Adapter::Hpricot::Error instead of ::Hpricot::Error
