### PR TITLE
Html To Plain Text improvements

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -73,6 +73,9 @@ module HtmlToPlainText
     # no more than two consecutive newlines
     txt.gsub!(/[\n]{3,}/, "\n\n")
 
+    # no more than two consecutive spaces
+    txt.gsub!(/ {2,}/, " ")
+
     txt.strip
   end
 

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -44,6 +44,7 @@ END_HTML
     assert_plaintext "a\na", "  \na \n a \t"
     assert_plaintext "a\n\na", "  \na \n\t \n \n a \t"
     assert_plaintext "test text", "test text&nbsp;"
+    assert_plaintext "test text", "test        text"
   end
 
   def test_wrapping_spans


### PR DESCRIPTION
Added additional stripping of unwanted space characters.

Fixed an issue with parsing links whereby the regex was too greedy so if there were multiple links inside a HTML block the HTML after the first anchor tag would be swallowed and discarded.
