### PR TITLE
Nokogiri choice of encoding 

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -194,7 +194,7 @@ class Premailer
           thing = thing.force_encoding('ASCII-8BIT').encode!
           doc = ::Nokogiri::XML(thing) {|c| c.recover }
         else
-          doc = ::Nokogiri::XML(thing, nil, 'ASCII-8BIT') {|c| c.recover }
+          doc = ::Nokogiri::XML(thing, nil, @options[:inputencoding] || 'ASCII-8BIT') {|c| c.recover }
         end
 
         return doc


### PR DESCRIPTION
sometime I get
  encoding error : output conversion failed due to conv error, bytes 0xAD 0x32 0x30 0x30

In order to fix this, I just had to set the encoding to UTF-8 instead. so making that available as an options
