### PR TITLE
Do not convert cid: urls

### DIFF
--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -356,7 +356,7 @@ public
       tags.each do |tag|
         # skip links that look like they have merge tags
         # and mailto, ftp, etc...
-        if tag.attributes[attribute].to_s =~ /^([\%\<\{\#\[]|data:|tel:|file:|sms:|callto:|facetime:|mailto:|ftp:|gopher:)/i
+        if tag.attributes[attribute].to_s =~ /^([\%\<\{\#\[]|data:|tel:|file:|sms:|callto:|facetime:|mailto:|ftp:|gopher:|cid:)/i
           next
         end
 


### PR DESCRIPTION
When using a base_url cid: urls try to be converted. These urls reference individual parts of an email
(http://tools.ietf.org/html/rfc2111) and shouldn't. 

This commit fixes this issue.
