### PR TITLE
Add separate flags to whether to include CSS from <link> and/or <style>

### DIFF
--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -212,4 +212,24 @@ END_HTML
   	  assert_equal '20', doc.at('td')['height']
   	end
   end
+
+  def test_include_link_tags_option
+    local_setup('base.html', :adapter => :nokogiri, :include_link_tags => true)
+    assert_match /1\.231/, @doc.at('body').attributes['style'].to_s
+    assert_match /display: none/, @doc.at('.hide').attributes['style'].to_s
+
+    local_setup('base.html', :adapter => :nokogiri, :include_link_tags => false)
+    assert_no_match /1\.231/, @doc.at('body').attributes['style'].to_s
+    assert_match /display: none/, @doc.at('.hide').attributes['style'].to_s
+  end
+
+  def test_include_style_tags_option
+    local_setup('base.html', :adapter => :nokogiri, :include_style_tags => true)
+    assert_match /1\.231/, @doc.at('body').attributes['style'].to_s
+    assert_match /display: block/, @doc.at('#iphone').attributes['style'].to_s
+
+    local_setup('base.html', :adapter => :nokogiri, :include_style_tags => false)
+    assert_match /1\.231/, @doc.at('body').attributes['style'].to_s
+    assert_no_match /display: block/, @doc.at('#iphone').attributes['style'].to_s
+  end
 end


### PR DESCRIPTION
Adding two extra options:
- `include_link_tags`
- `include_style_tags`

They both default to true, which will not change functionality.

Where this is helpful is when I have mobile specific CSS in the <style> tag and don't want the mobile css to be inlined.
