### PR TITLE
Sort style attributes

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -75,7 +75,7 @@ class Premailer
           end
 
           # write the inline STYLE attribute
-          el['style'] = Premailer.escape_string(merged.declarations_to_s)
+          el['style'] = Premailer.escape_string(merged.declarations_to_s).split(';').map(&:strip).sort.join('; ')
         end
 
         doc = write_unmergable_css_rules(doc, @unmergable_rules)

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -209,7 +209,7 @@ END_HTML
 
     premailer = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri)
   	premailer.to_inline_css
-    assert_equal 'color: green !important;', premailer.processed_doc.search('p').first.attributes['style'].to_s
+    assert_equal 'color: green !important', premailer.processed_doc.search('p').first.attributes['style'].to_s
   end
 
   # in response to https://github.com/alexdunae/premailer/issues/28
@@ -231,6 +231,23 @@ END_HTML
   	premailer.to_inline_css
     assert_match /margin: 0 auto;/, premailer.processed_doc.search('#page').first.attributes['style'].to_s
     assert_match /border-style: solid none solid solid;/, premailer.processed_doc.search('p').first.attributes['style'].to_s
+  end
+
+  def test_sorting_style_attributes
+    html = <<END_HTML
+    <html>
+    <style type="text/css">
+      #page { right: 10px; left: 5px }
+    </style>
+    <body>
+      <div id='page'>test</div>
+    </body>
+    </html>
+END_HTML
+
+    premailer = Premailer.new(html, :with_html_string => true)
+    premailer.to_inline_css
+    assert_equal "left: 5px; right: 10px", premailer.processed_doc.search('#page').first.attributes['style'].to_s
   end
 
   def test_removing_scripts


### PR DESCRIPTION
Sort style attributes to make the output from premailer consistent. Though this is not strictly necessary it is nice to know what Premailer will do when writing tests.
