### PR TITLE
Use input_encoding to set encoding with Nokogiri

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -207,7 +207,7 @@ class Premailer
         # However, we really don't want to hardcode this. ASCII-8BIG should be the default, but not the only option.
         if thing.is_a?(String) and RUBY_VERSION =~ /1.9/
           thing = thing.force_encoding(@options[:input_encoding]).encode!
-          doc = ::Nokogiri::HTML(thing) {|c| c.recover }
+          doc = ::Nokogiri::HTML(thing, nil, @options[:input_encoding]) {|c| c.recover }
         else
           default_encoding = RUBY_PLATFORM == 'java' ? nil : 'BINARY'
           doc = ::Nokogiri::HTML(thing, nil, @options[:input_encoding] || default_encoding) {|c| c.recover }

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -240,6 +240,20 @@ END_HTML
     assert_equal expected_html, pm.to_inline_css
   end
 
+  def test_meta_encoding_downcase
+    meta_encoding = '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">'
+    expected_html = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">'
+    pm = Premailer.new(meta_encoding, :with_html_string => true, :adapter => :nokogiri, :input_encoding => "utf-8")
+    assert_match expected_html, pm.to_inline_css
+  end
+
+  def test_meta_encoding_upcase
+    meta_encoding = '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">'
+    expected_html = '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">'
+    pm = Premailer.new(meta_encoding, :with_html_string => true, :adapter => :nokogiri, :input_encoding => "UTF-8")
+    assert_match expected_html, pm.to_inline_css
+  end
+
   def test_htmlentities
     html_entities = "&#8217;"
     expected_html = "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\" \"http://www.w3.org/TR/REC-html40/loose.dtd\">\n<html><body><p>'</p></body></html>\n"


### PR DESCRIPTION
To ensure we get the right capitalization of the encoding in the meta tag we can tell Nokogiri what the encoding should be. If we don't Nokogiri might randomly decide on an upper or lowercase formatting.
