### PR TITLE
Handle the case when there are new lines inside a <a> tag

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -13,7 +13,7 @@ module HtmlToPlainText
     # decode HTML entities
     he = HTMLEntities.new
     txt = he.decode(txt)
-    
+
     # replace image by their alt attribute
     txt.gsub!(/<img.+?alt=\"([^\"]*)\"[^>]*\/>/i, '\1')
 
@@ -22,12 +22,12 @@ module HtmlToPlainText
     txt.gsub!(/<img.+?alt='([^\']*)\'[^>]*\/>/i, '\1')
 
     # links
-    txt.gsub!(/<a.+?href=\"([^\"]*)\"[^>]*>(.+?)<\/a>/i) do |s|
-      $2.strip + ' ( ' + $1.strip + ' )'
+    txt.gsub!(/<a.+?href=\"(mailto:)?([^\"]*)\"[^>]*>((.|\s)+?)<\/a>/i) do |s|
+      $3.strip + ' ( ' + $2.strip + ' )'
     end
 
-    txt.gsub!(/<a.+?href='([^\']*)\'[^>]*>(.+?)<\/a>/i) do |s|
-      $2.strip + ' ( ' + $1.strip + ' )'
+    txt.gsub!(/<a.+?href='(mailto:)?([^\']*)\'[^>]*>((.|\s)+?)<\/a>/i) do |s|
+      $3.strip + ' ( ' + $2.strip + ' )'
     end
 
 
@@ -73,7 +73,7 @@ module HtmlToPlainText
     txt.gsub!(/<\/?[^>]*>/, '')
 
     txt = word_wrap(txt, line_length)
-    
+
     # remove linefeeds (\r\n and \r -> \n)
     txt.gsub!(/\r\n?/, "\n")
 
@@ -87,7 +87,7 @@ module HtmlToPlainText
 
     # no more than two consecutive spaces
     txt.gsub!(/ {2,}/, " ")
-    
+
     # the word messes up the parens
     txt.gsub!(/\([ \n](http[^)]+)[\n ]\)/) do |s|
       "( " + $1 + " )"

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -108,7 +108,13 @@ END_HTML
     
     # nested html
     assert_plaintext 'Link ( http://example.com/ )', '<a href="http://example.com/"><span class="a">Link</span></a>'
-    
+
+    # nested html with new line
+    assert_plaintext 'Link ( http://example.com/ )', "<a href='http://example.com/'>\n\t<span class='a'>Link</span>\n\t</a>"
+
+    # mailto
+    assert_plaintext 'Contact Us ( contact@example.org )', "<a href='mailto:contact@example.org'>Contact Us</a>"
+
     # complex link
     assert_plaintext 'Link ( http://example.com:80/~user?aaa=bb&c=d,e,f#foo )', '<a href="http://example.com:80/~user?aaa=bb&amp;c=d,e,f#foo">Link</a>'
     


### PR DESCRIPTION
Hi,

Before the patch:
`<a href='http://example.com/'>\n\t<span class='a'>Link</span>\n\t</a>` => `Link`
After the patch:
`<a href='http://example.com/'>\n\t<span class='a'>Link</span>\n\t</a>` => `Link ( http://example.com/ )`

I've also handled `mailto:` link, i.e.:
`<a href='mailto:contact@example.org'>Contact Us</a>` => `Contact Us ( contact@example.org )` (instead of `Contact Us ( mailto:contact@example.org )`)

Thanks!
