### PR TITLE
Correctly handle encoded angle brackets.

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -10,10 +10,6 @@ module HtmlToPlainText
   def convert_to_text(html, line_length = 65, from_charset = 'UTF-8')
     txt = html
 
-    # decode HTML entities
-    he = HTMLEntities.new
-    txt = he.decode(txt)
-    
     # replace image by their alt attribute
     txt.gsub!(/<img.+?alt=\"([^\"]*)\"[^>]*\/>/i, '\1')
 
@@ -72,8 +68,12 @@ module HtmlToPlainText
     # strip remaining tags
     txt.gsub!(/<\/?[^>]*>/, '')
 
+    # decode HTML entities
+    he = HTMLEntities.new
+    txt = he.decode(txt)
+
     txt = word_wrap(txt, line_length)
-    
+
     # remove linefeeds (\r\n and \r -> \n)
     txt.gsub!(/\r\n?/, "\n")
 
@@ -87,7 +87,7 @@ module HtmlToPlainText
 
     # no more than two consecutive spaces
     txt.gsub!(/ {2,}/, " ")
-    
+
     # the word messes up the parens
     txt.gsub!(/\([ \n](http[^)]+)[\n ]\)/) do |s|
       "( " + $1 + " )"

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -45,6 +45,7 @@ END_HTML
     assert_plaintext "a\n\na", "  \na \n\t \n \n a \t"
     assert_plaintext "test text", "test text&nbsp;"
     assert_plaintext "test text", "test        text"
+    assert_plaintext "<test text>", "&lt;test text&gt;"
   end
 
   def test_wrapping_spans
@@ -69,7 +70,7 @@ END_HTML
     assert_plaintext "* item 1\n* item 2", "<li class='123'>item 1</li> <li>item 2</li>\n"
     assert_plaintext "* item 1\n* item 2\n* item 3", "<li>item 1</li> \t\n <li>item 2</li> <li> item 3</li>\n"
   end
-  
+
   def test_stripping_html
     assert_plaintext 'test text', "<p class=\"123'45 , att\" att=tester>test <span class='te\"st'>text</span>\n"
   end
@@ -81,7 +82,7 @@ END_HTML
     assert_plaintext "Test text\nTest text", "\n<p>Test text<br> \tTest text<br></p>\n"
     assert_plaintext "Test text\n\nTest text", "Test text<br><BR />Test text"
   end
-  
+
   def test_headings
     assert_plaintext "****\nTest\n****", "<h1>Test</h1>"
     assert_plaintext "****\nTest\n****", "\t<h1>\nTest</h1> "
@@ -90,7 +91,7 @@ END_HTML
     assert_plaintext "----\nTest\n----", "<h2>Test</h2>"
     assert_plaintext "Test\n----", "<h3> <span class='a'>Test </span></h3>"
   end
-  
+
   def test_wrapping_lines
     raw = ''
     100.times { raw += 'test ' }
@@ -105,19 +106,19 @@ END_HTML
   def test_links
     # basic
     assert_plaintext 'Link ( http://example.com/ )', '<a href="http://example.com/">Link</a>'
-    
+
     # nested html
     assert_plaintext 'Link ( http://example.com/ )', '<a href="http://example.com/"><span class="a">Link</span></a>'
-    
+
     # complex link
     assert_plaintext 'Link ( http://example.com:80/~user?aaa=bb&c=d,e,f#foo )', '<a href="http://example.com:80/~user?aaa=bb&amp;c=d,e,f#foo">Link</a>'
-    
+
     # attributes
     assert_plaintext 'Link ( http://example.com/ )', '<a title=\'title\' href="http://example.com/">Link</a>'
-    
+
     # spacing
     assert_plaintext 'Link ( http://example.com/ )', '<a href="   http://example.com/ "> Link </a>'
-    
+
     # multiple
     assert_plaintext 'Link A ( http://example.com/a/ ) Link B ( http://example.com/b/ )', '<a href="http://example.com/a/">Link A</a> <a href="http://example.com/b/">Link B</a>'
 
@@ -125,21 +126,21 @@ END_HTML
     assert_plaintext 'Link ( %%LINK%% )', '<a href="%%LINK%%">Link</a>'
     assert_plaintext 'Link ( [LINK] )', '<a href="[LINK]">Link</a>'
     assert_plaintext 'Link ( {LINK} )', '<a href="{LINK}">Link</a>'
-    
+
     # unsubscribe
     assert_plaintext 'Link ( [[!unsubscribe]] )', '<a href="[[!unsubscribe]]">Link</a>'
   end
-  
+
   # see https://github.com/alexdunae/premailer/issues/72
   def test_multiple_links_per_line
-    assert_plaintext 'This is link1 ( http://www.google.com ) and link2 ( http://www.google.com ) is next.', 
+    assert_plaintext 'This is link1 ( http://www.google.com ) and link2 ( http://www.google.com ) is next.',
                      '<p>This is <a href="http://www.google.com" >link1</a> and <a href="http://www.google.com" >link2 </a> is next.</p>',
                      nil, 10000
   end
 
   # see https://github.com/alexdunae/premailer/issues/72
   def test_links_within_headings
-    assert_plaintext "****************************\nTest ( http://example.com/ )\n****************************", 
+    assert_plaintext "****************************\nTest ( http://example.com/ )\n****************************",
                      "<h1><a href='http://example.com/'>Test</a></h1>"
   end
 


### PR DESCRIPTION
`HtmlToPlainText#convert_to_text` clobbers all text between the html entities "&amp;lt;" and "&amp;gt;". 

This is because we do entity replacement, converting the entities into angle brackets, and then strip out remaining tags.

This commit fixes the issue by doing entity replacement **after** we strip out tags.

Before this commit:

``` ruby
Premailer.new("&lt;test&gt;", :with_html_string => true).to_plain_text
# Erroneously returns ""
```

After this commit:

``` ruby
Premailer.new("&lt;test&gt;", :with_html_string => true).to_plain_text
# Correctly returns "<test>"
```
