### PR TITLE
Improve command line mode detection for arguments vs. STDIN

### DIFF
--- a/lib/premailer/executor.rb
+++ b/lib/premailer/executor.rb
@@ -77,9 +77,11 @@ $stderr.puts "Processing in #{mode} mode with options #{options.inspect}" if opt
 premailer = nil
 input = nil
 
-if $stdin.tty?
+if ARGV.size > 0
+  # Executed via command line or shell script
   input = ARGV.shift
 else
+  # Called in piped command
   input = $stdin.read
   options[:with_html_string] = true
 end


### PR DESCRIPTION
Fix #163 by checking for ARGV.size instead of $stdin.tty?. This way, files can be passed by argument within a BASH or Ant script in addition to allowing STDIN.
