### PR TITLE
Add support for HTML Entity encoding output when using Nokogiri

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -121,9 +121,9 @@ class Premailer
         @processed_doc = doc
         if is_xhtml?
           # we don't want to encode carriage returns
-          @processed_doc.to_xhtml(:encoding => nil).gsub(/&\#(xD|13);/i, "\r")
+          @processed_doc.to_xhtml(encoding:@options[:output_encoding]).gsub(/&\#(xD|13);/i, "\r")
         else
-          @processed_doc.to_html
+          @processed_doc.to_html(encoding:@options[:output_encoding])
         end
       end
 
@@ -186,10 +186,10 @@ class Premailer
         # TODO: duplicate options
         if @options[:with_html_string] or @options[:inline] or input.respond_to?(:read)
           thing = input
-				elsif @is_local_file
+        elsif @is_local_file
           @base_dir = File.dirname(input)
           thing = File.open(input, 'r')
-				else
+        else
           thing = open(input)
         end
 

--- a/lib/premailer/executor.rb
+++ b/lib/premailer/executor.rb
@@ -52,6 +52,10 @@ opts = OptionParser.new do |opts|
     options[:line_length] = v
   end
 
+  opts.on("-e", "--entities", "Output HTML entities instead of UTF-8 when using Nokogiri") do |v|
+    options[:output_encoding] = "US-ASCII"
+  end
+
   opts.on("-d", "--io-exceptions", "Abort on I/O errors") do |v|
     options[:io_exceptions] = v
   end

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -207,6 +207,7 @@ class Premailer
                 :include_link_tags => true,
                 :include_style_tags => true,
                 :input_encoding => 'ASCII-8BIT',
+                :output_encoding => nil,
                 :replace_html_entities => false,
                 :adapter => Adapter.use,
                 }.merge(options)


### PR DESCRIPTION
Added a new option **output_encoding** and (a -e flag for the command line executable) so that output with HTML Entities is possible when using Nokogiri. Default behavior is still UTF-8.

This should fix issues #30, #126, and possibly #68, #74 
