### PR TITLE
Strip !important declarations in HTML attributes.

### DIFF
--- a/lib/premailer/adapter/hpricot.rb
+++ b/lib/premailer/adapter/hpricot.rb
@@ -80,7 +80,7 @@ class Premailer
           # Duplicate CSS attributes as HTML attributes
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name)
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
-              el[html_att] = merged[css_att].gsub(/url\('(.*)'\)/,'\1').gsub(/;$/, '').strip if el[html_att].nil? and not merged[css_att].empty?
+              el[html_att] = merged[css_att].gsub(/url\('(.*)'\)/,'\1').gsub(/;$|\s*!important/, '').strip if el[html_att].nil? and not merged[css_att].empty?
             end
           end
 

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -76,7 +76,7 @@ class Premailer
           # Duplicate CSS attributes as HTML attributes
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name)
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
-              el[html_att] = merged[css_att].gsub(/url\('(.*)'\)/,'\1').gsub(/;$/, '').strip if el[html_att].nil? and not merged[css_att].empty?
+              el[html_att] = merged[css_att].gsub(/url\('(.*)'\)/,'\1').gsub(/;$|\s*!important/, '').strip if el[html_att].nil? and not merged[css_att].empty?
             end
           end
 

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -321,4 +321,22 @@ END_HTML
     end
   end
 
+  def test_strip_important_from_attributes
+    html = <<END_HTML
+    <html>
+    <head>
+      <style>td { background-color: #FF0000 !important; }</style>
+    </head>
+    <body>
+      <table><tr><td>red</td></tr></table>
+    </body>
+    </html>
+END_HTML
+
+    [:nokogiri, :hpricot].each do |adapter|
+      premailer = Premailer.new(html, :with_html_string => true, :adapter => adapter)
+      assert_match 'bgcolor="#FF0000"', premailer.to_inline_css
+    end
+  end
+
 end


### PR DESCRIPTION
If a `background-color` declaration has `!important`, it will carry over into `bgcolor` attributes which can cause parser errors (e.g. strange colors.)
