### PR TITLE
Fixes teeny tiny spelling error in README.md "ouput.txt" -> "output.txt"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ File.open("output.html", "w") do |fout|
 end
 
 # Write the plain-text output
-File.open("ouput.txt", "w") do |fout|
+File.open("output.txt", "w") do |fout|
   fout.puts premailer.to_plain_text
 end
 


### PR DESCRIPTION
Yeah, I'm _that_ guy who submits one character pull requests.

`ouput.txt`:arrow_right:`output.txt`
