### PR TITLE
Rescue StandardError instead of Exception

### DIFF
--- a/lib/premailer/adapter/hpricot.rb
+++ b/lib/premailer/adapter/hpricot.rb
@@ -158,7 +158,7 @@ class Premailer
         html_src = ''
         begin
           html_src = @doc.search("body").inner_html
-        rescue; end
+        rescue StandardError; end
 
         html_src = @doc.to_html unless html_src and not html_src.empty?
         convert_to_text(html_src, @options[:line_length], @html_encoding)

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -161,7 +161,7 @@ class Premailer
         html_src = ''
         begin
           html_src = @doc.at("body").inner_html
-        rescue; end
+        rescue StandardError; end
 
         html_src = @doc.to_html unless html_src and not html_src.empty?
         convert_to_text(html_src, @options[:line_length], @html_encoding)

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -252,7 +252,7 @@ protected
       end
 
       load_css_from_string(css_block)
-    rescue; end
+    rescue StandardError; end
   end
 
   def load_css_from_string(css_string)
@@ -343,7 +343,7 @@ public
 
     begin
       current_host = @base_url.host
-    rescue
+    rescue StandardError
       current_host = nil
     end
 
@@ -421,15 +421,15 @@ public
         if tag.attributes[attribute].to_s =~ /^http/i
           begin
             merged = URI.parse(tag.attributes[attribute])
-          rescue; next; end
+          rescue StandardError; next; end
         else
           begin
             merged = Premailer.resolve_link(tag.attributes[attribute].to_s, base_uri)
-          rescue
+          rescue StandardError
             begin
               next unless escape_attrs
               merged = Premailer.resolve_link(URI.escape(tag.attributes[attribute].to_s), base_uri)
-            rescue; end
+            rescue StandardError; end
           end
         end
 


### PR DESCRIPTION
It is bad style to rescue Exception, because it is the root of the
exception hierarchy, and includes SyntaxError, Interrupt, and Signal
Exception.

For more information see:
https://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby
