### PR TITLE
Fix htmlentities version for ruby 1.8.7 support

### DIFF
--- a/gemfiles/ruby187.gemspec
+++ b/gemfiles/ruby187.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files       = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables      = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.add_dependency('css_parser', '>= 1.3.5')
-  s.add_dependency('htmlentities', '>= 4.0.0')
+  s.add_dependency('htmlentities', [ '>= 4.0.0', '<= 4.3.1' ])
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency('rake', ['~> 0.8',  '!= 0.9.0'])
   s.add_development_dependency('hpricot', '>= 0.8.3')


### PR DESCRIPTION
htmlentities 4.3.2+ doesn't support ruby 1.8.x
