### PR TITLE
Fix plaintext email for lines with multiple links

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -26,8 +26,7 @@ module HtmlToPlainText
     txt.gsub!(/<img.+?alt=\'([^\']*)\'[^>]*\>/i, '\1')
 
     # links
-    # txt.gsub!(/<a.+?href=\"(mailto:)?([^\"]*)\"[^>]*>((.|\s)*?)<\/a>/i) do |s|
-    txt.gsub!(/<a\s.*href=\"(mailto:)?([^\"]*)\"[^>]*>((.|\s)*?)<\/a>/i) do |s|
+    txt.gsub!(/<a\s.*?href=\"(mailto:)?([^\"]*)\"[^>]*>((.|\s)*?)<\/a>/i) do |s|
       if $3.empty?
         ''
       else
@@ -35,7 +34,6 @@ module HtmlToPlainText
       end
     end
 
-    # txt.gsub!(/<a.+?href='(mailto:)?([^\']*)\'[^>]*>((.|\s)*?)<\/a>/i) do |s|
     txt.gsub!(/<a\s.*?href='(mailto:)?([^\']*)\'[^>]*>((.|\s)*?)<\/a>/i) do |s|
       if $3.empty?
         ''


### PR DESCRIPTION
Resolve broken plaintext email conversion for lines with multiple links, prev introduced with greedy regex in https://github.com/premailer/premailer/commit/b6779527b5d9c2c224027e92c98bf3dca3e704ea#diff-13d400fc965c7276f2c7f6ae54c26aebR30

Fixes broken tests:
- https://github.com/premailer/premailer/blob/master/test/test_html_to_plain_text.rb#L142
- https://github.com/premailer/premailer/blob/master/test/test_html_to_plain_text.rb#L158
