### PR TITLE
remove CDATA from script tags in addition to style tags

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -216,9 +216,13 @@ class Premailer
           doc = ::Nokogiri::HTML(thing, nil, @options[:input_encoding] || default_encoding) {|c| c.recover }
         end
 
-        # Fix for removing any CDATA tags inserted per https://github.com/sparklemotion/nokogiri/issues/311
-        doc.search("style").children.each do |child|
-          child.swap(child.text()) if child.cdata?
+        # Fix for removing any CDATA tags from both style and script tags inserted per
+        # https://github.com/sparklemotion/nokogiri/issues/311 and
+        # https://github.com/premailer/premailer/issues/199
+        %w(style script).each do |tag|
+          doc.search(tag).children.each do |child|
+            child.swap(child.text()) if child.cdata?
+          end
         end
 
         doc

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -340,4 +340,34 @@ END_HTML
     end
   end
 
+  def test_scripts_with_nokogiri
+    html = <<END_HTML
+    <html>
+    <body>
+    <script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@type": "Person",
+      "name": "John Doe",
+      "jobTitle": "Graduate research assistant",
+      "affiliation": "University of Dreams",
+      "additionalName": "Johnny",
+      "url": "http://www.example.com",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "1234 Peach Drive",
+        "addressLocality": "Wonderland",
+        "addressRegion": "Georgia"
+      }
+    }
+    </script
+    </body>
+    </html>
+END_HTML
+
+    premailer = Premailer.new(html, :with_html_string => true, :remove_scripts => false, :adapter => :nokogiri)
+    premailer.to_inline_css
+
+    assert !premailer.processed_doc.css('script[type="application/ld+json"]').first.children.first.cdata?
+  end
 end


### PR DESCRIPTION
Remove CDATA from script tags in the same way that we remove CDATA from style tags.

This branch addresses https://github.com/premailer/premailer/issues/199
