### PR TITLE
Option to reset contenteditable attributes

### DIFF
--- a/lib/premailer/adapter/hpricot.rb
+++ b/lib/premailer/adapter/hpricot.rb
@@ -102,6 +102,12 @@ class Premailer
           end
         end
 
+        if @options[:reset_contenteditable]
+          doc.search('*[@contenteditable]').each do |el|
+            el.remove_attribute('contenteditable')
+          end
+        end
+
         if @options[:remove_ids]
           # find all anchor's targets and hash them
           targets = []

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -118,6 +118,12 @@ class Premailer
           end
         end
 
+        if @options[:reset_contenteditable]
+          doc.search('*[@contenteditable]').each do |el|
+            el.remove_attribute('contenteditable')
+          end
+        end
+
         @processed_doc = doc
         if is_xhtml?
           # we don't want to encode carriage returns

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -156,6 +156,7 @@ class Premailer
   # @option options [Boolean] :remove_classes Remove class attributes. Default is false.
   # @option options [Boolean] :remove_comments Remove html comments. Default is false.
   # @option options [Boolean] :remove_scripts Remove <tt>script</tt> elements. Default is true.
+  # @option options [Boolean] :reset_contenteditable Remove <tt>contenteditable</tt> attributes. Default is true.
   # @option options [Boolean] :preserve_styles Whether to preserve any <tt>link rel=stylesheet</tt> and <tt>style</tt> elements.  Default is false.
   # @option options [Boolean] :preserve_reset Whether to preserve styles associated with the MailChimp reset code. Default is true.
   # @option options [Boolean] :with_html_string Whether the html param should be treated as a raw string. Default is false.
@@ -176,6 +177,7 @@ class Premailer
                 :remove_ids => false,
                 :remove_comments => false,
                 :remove_scripts => true,
+                :reset_contenteditable => true,
                 :css => [],
                 :css_to_attributes => true,
                 :with_html_string => false,

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -204,6 +204,23 @@ END_HTML
   	end
   end
 
+  def test_reset_contenteditable
+    html = <<-___
+    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+    <html> <head> <style type="text/css"> #remove { color:blue; } </style> </head>
+    <body>
+    <div contenteditable="true" id="editable"> Test </div>
+    </body> </html>
+    ___
+    [:nokogiri, :hpricot].each do |adapter|
+  		pm = Premailer.new(html, :with_html_string => true, :reset_contenteditable => true, :adapter => adapter)
+      pm.to_inline_css
+      doc = pm.processed_doc
+  	  assert_nil doc.at('#editable')['contenteditable'],
+        "#{adapter}: contenteditable attribute not removed"
+  	end
+  end
+
   def test_carriage_returns_as_entities
     html = <<-html
     <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">


### PR DESCRIPTION
Elements with contenteditable should normally be ignored by mail clients, but they should not be set as editable in the output anyway. This makes it easier to use with rendering "view on web" with the same content as in email.
