### PR TITLE
bump htmlentities to 4.3.3

### DIFF
--- a/premailer.gemspec
+++ b/premailer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files       = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables      = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.add_dependency('css_parser', '>= 1.3.6')
-  s.add_dependency('htmlentities', [ '>= 4.0.0', '<= 4.3.3' ])
+  s.add_dependency('htmlentities', ['>= 4.0.0'])
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency('rake', ['~> 0.8',  '!= 0.9.0'])
   s.add_development_dependency('hpricot', '>= 0.8.3')

--- a/premailer.gemspec
+++ b/premailer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files       = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables      = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.add_dependency('css_parser', '>= 1.3.6')
-  s.add_dependency('htmlentities', [ '>= 4.0.0', '<= 4.3.1' ])
+  s.add_dependency('htmlentities', [ '>= 4.0.0', '<= 4.3.3' ])
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency('rake', ['~> 0.8',  '!= 0.9.0'])
   s.add_development_dependency('hpricot', '>= 0.8.3')


### PR DESCRIPTION
This removes a warning from ruby 2.2.