### PR TITLE
Add ignore blocks for text generation

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -10,6 +10,11 @@ module HtmlToPlainText
   def convert_to_text(html, line_length = 65, from_charset = 'UTF-8')
     txt = html
 
+    # strip text ignored html. Useful for removing
+    # headers and footers that aren't needed in the
+    # text version
+    txt.gsub!(/<!-- start text\/html -->.*?<!-- end text\/html -->/m, '')
+
     # replace images with their alt attributes
     # for img tags with "" for attribute quotes
     # with or without closing tag

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -69,9 +69,21 @@ END_HTML
     assert_plaintext "* item 1\n* item 2", "<li class='123'>item 1</li> <li>item 2</li>\n"
     assert_plaintext "* item 1\n* item 2\n* item 3", "<li>item 1</li> \t\n <li>item 2</li> <li> item 3</li>\n"
   end
-  
+
   def test_stripping_html
     assert_plaintext 'test text', "<p class=\"123'45 , att\" att=tester>test <span class='te\"st'>text</span>\n"
+  end
+
+  def test_stripping_ignored_blocks
+    html = <<END_HTML
+    <p>test</p>
+    <!-- start text/html -->
+      <img src="logo.png" alt="logo">
+    <!-- end text/html -->
+    <p>text</p>
+END_HTML
+    premailer = Premailer.new(html, :with_html_string => true)
+    assert_match /test\n\ntext/, premailer.to_plain_text
   end
 
   def test_paragraphs_and_breaks
@@ -81,7 +93,7 @@ END_HTML
     assert_plaintext "Test text\nTest text", "\n<p>Test text<br> \tTest text<br></p>\n"
     assert_plaintext "Test text\n\nTest text", "Test text<br><BR />Test text"
   end
-  
+
   def test_headings
     assert_plaintext "****\nTest\n****", "<h1>Test</h1>"
     assert_plaintext "****\nTest\n****", "\t<h1>\nTest</h1> "
@@ -90,7 +102,7 @@ END_HTML
     assert_plaintext "----\nTest\n----", "<h2>Test</h2>"
     assert_plaintext "Test\n----", "<h3> <span class='a'>Test </span></h3>"
   end
-  
+
   def test_wrapping_lines
     raw = ''
     100.times { raw += 'test ' }
@@ -103,7 +115,7 @@ END_HTML
   end
 
   def test_img_alt_tags
-    # ensure html imag tags that aren't self-closed are parsed, 
+    # ensure html imag tags that aren't self-closed are parsed,
     # along with accepting both '' and "" as attribute quotes
 
     # <img alt="" />
@@ -119,7 +131,7 @@ END_HTML
   def test_links
     # basic
     assert_plaintext 'Link ( http://example.com/ )', '<a href="http://example.com/">Link</a>'
-    
+
     # nested html
     assert_plaintext 'Link ( http://example.com/ )', '<a href="http://example.com/"><span class="a">Link</span></a>'
 
@@ -131,13 +143,13 @@ END_HTML
 
     # complex link
     assert_plaintext 'Link ( http://example.com:80/~user?aaa=bb&c=d,e,f#foo )', '<a href="http://example.com:80/~user?aaa=bb&amp;c=d,e,f#foo">Link</a>'
-    
+
     # attributes
     assert_plaintext 'Link ( http://example.com/ )', '<a title=\'title\' href="http://example.com/">Link</a>'
-    
+
     # spacing
     assert_plaintext 'Link ( http://example.com/ )', '<a href="   http://example.com/ "> Link </a>'
-    
+
     # multiple
     assert_plaintext 'Link A ( http://example.com/a/ ) Link B ( http://example.com/b/ )', '<a href="http://example.com/a/">Link A</a> <a href="http://example.com/b/">Link B</a>'
 
@@ -145,24 +157,24 @@ END_HTML
     assert_plaintext 'Link ( %%LINK%% )', '<a href="%%LINK%%">Link</a>'
     assert_plaintext 'Link ( [LINK] )', '<a href="[LINK]">Link</a>'
     assert_plaintext 'Link ( {LINK} )', '<a href="{LINK}">Link</a>'
-    
+
     # unsubscribe
     assert_plaintext 'Link ( [[!unsubscribe]] )', '<a href="[[!unsubscribe]]">Link</a>'
 
     # empty link gets dropped, and shouldn't run forever
     assert_plaintext(("This is some more text\n\n" * 14 + "This is some more text"), "<a href=\"test\"></a>#{"\n<p>This is some more text</p>" * 15}")
   end
-  
+
   # see https://github.com/alexdunae/premailer/issues/72
   def test_multiple_links_per_line
-    assert_plaintext 'This is link1 ( http://www.google.com ) and link2 ( http://www.google.com ) is next.', 
+    assert_plaintext 'This is link1 ( http://www.google.com ) and link2 ( http://www.google.com ) is next.',
                      '<p>This is <a href="http://www.google.com" >link1</a> and <a href="http://www.google.com" >link2 </a> is next.</p>',
                      nil, 10000
   end
 
   # see https://github.com/alexdunae/premailer/issues/72
   def test_links_within_headings
-    assert_plaintext "****************************\nTest ( http://example.com/ )\n****************************", 
+    assert_plaintext "****************************\nTest ( http://example.com/ )\n****************************",
                      "<h1><a href='http://example.com/'>Test</a></h1>"
   end
 


### PR DESCRIPTION
Use <!-- start text/html--> blah blah <!-- end text/html --> to ignore blocks of html in the text email. Fixes #239