### PR TITLE
add option to unescape ampersand

### DIFF
--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -193,6 +193,7 @@ class Premailer
                 :output_encoding => nil,
                 :replace_html_entities => false,
                 :escape_url_attributes => true,
+                :unescaped_ampersand => false,
                 :adapter => Adapter.use,
                 }.merge(options)
 
@@ -371,7 +372,8 @@ public
         end
 
         if href.query and not href.query.empty?
-          href.query = href.query + '&amp;' + qs
+          amp = @options[:unescaped_ampersand] ? '&' : '&amp;'
+          href.query = href.query + amp + qs
         else
           href.query = qs
         end

--- a/test/test_links.rb
+++ b/test/test_links.rb
@@ -77,6 +77,16 @@ class TestLinks < Premailer::TestCase
     assert_equal '/test/?123&456&amp;utm_source=1234', premailer.processed_doc.at('a')['href']
   end
 
+  def test_unescape_ampersand
+    qs = 'utm_source=1234'
+
+    premailer = Premailer.new("<a href='/test/?q=query'>Link</a>", :link_query_string => qs, :with_html_string => true, :unescaped_ampersand => true)
+    premailer.to_inline_css
+
+    premailer.processed_doc.search('a').each do |a|
+      assert_equal '/test/?q=query&utm_source=1234', a['href'].to_s
+    end
+  end
 
   def test_preserving_links
     html = "<a href='http://example.com/index.php?pram1=one&pram2=two'>Link</a>"


### PR DESCRIPTION
This PR add an option called : unescaped_ampersand that when set to `true` should fix [#174](https://github.com/premailer/premailer/issues/174) and all the other related issues.
Check [this](http://stackoverflow.com/questions/19441750/do-ampersands-still-need-to-be-encoded-in-urls-in-html5) and [this](http://www.w3.org/TR/html401/appendix/notes.html#h-B.2.2), because using just `&` is not valid HTML4 and might be invalid HTML5 as well. But browsers just doesn't unescape it properly.