### PR TITLE
Fix Nokogiri adapter empty string handling.

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -144,7 +144,7 @@ class Premailer
 
         unless styles.empty?
           style_tag = "<style type=\"text/css\">\n#{styles}</style>"
-          if body = doc.search('body')
+          unless (body = doc.search('body')).empty?
             if doc.at_css('body').children && !doc.at_css('body').children.empty?
               doc.at_css('body').children.before(::Nokogiri::XML.fragment(style_tag))
             else

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -334,4 +334,14 @@ END_HTML
     end
   end
 
+  def test_empty_html_nokogiri
+    html = ""
+    css = "a:hover {color:red;}"
+
+    assert_nothing_raised do
+      pm = Premailer.new(html, :with_html_string => true, :css_string => css, :adapter => :nokogiri)
+      pm.to_inline_css
+    end
+  end
+
 end


### PR DESCRIPTION
When using the Nokogiri adapter, parsing an empty string or file raises an error because a guard that checks for a body is improperly implemented.  This pull request fixes the guard to check for an empty array returned from `doc.search('body')` instead of checking for a truthy value.  