### PR TITLE
Update Gemfile to include test-unit on MRI 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,9 @@ matrix:
       gemfile: gemfiles/.ruby187.gemfile
     - rvm: 2.0.0
       gemfile: gemfiles/.ruby187.gemfile
+    - rvm: 2.1.0
+      gemfile: gemfiles/.ruby187.gemfile
+    - rvm: 2.2.0
+      gemfile: gemfiles/.ruby187.gemfile
     - rvm: ree
       gemfile: Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ rvm:
 gemfile:
   - Gemfile
   - gemfiles/.ruby187.gemfile
+before_install:
+  - gem install bundler
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,4 @@ gem "ripper", :group => :development, :platforms => :mri_18
 
 gem "coveralls", :require => false, :platforms => [:mri_19, :mri_20], :group => :development
 
-gem 'test-unit', :group => [:development, :test], :platforms => [:mri_20]
+gem 'test-unit', :group => [:development, :test], :platforms => [:mri_20, :mri_22]


### PR DESCRIPTION
This fixes the tests for Ruby 2.2. Travis CI lists as failing right now, which worried me as I was considering this library for a project.