### PR TITLE
Allows removal of url("...") in nokogiri RELATED_ATTRIBUTES

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -76,7 +76,7 @@ class Premailer
           # Duplicate CSS attributes as HTML attributes
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name)
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
-              el[html_att] = merged[css_att].gsub(/url\('(.*)'\)/, '\1').gsub(/;$|\s*!important/, '').strip if el[html_att].nil? and not merged[css_att].empty?
+              el[html_att] = merged[css_att].gsub(/url\(['|"](.*)['|"]\)/, '\1').gsub(/;$|\s*!important/, '').strip if el[html_att].nil? and not merged[css_att].empty?
             end
           end
 


### PR DESCRIPTION
I had encountered an issue where `background-image`'s were been converted to attributes with the `url('...')` property as well. So I was seeing:

```
background='url("http://cdn.ymaservices.com/email_transactional/background.jpg?v=0000002")'
```

It was not being stripped due to the URL being wrapped in `"` and not `'`. This change ensures either will work.

```
background='http://cdn.ymaservices.com/email_transactional/background.jpg?v=0000002'
```
