### PR TITLE
Remove inline styles which are attributes

### DIFF
--- a/lib/premailer/adapter/hpricot.rb
+++ b/lib/premailer/adapter/hpricot.rb
@@ -81,6 +81,9 @@ class Premailer
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name)
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               el[html_att] = merged[css_att].gsub(/url\('(.*)'\)/,'\1').gsub(/;$|\s*!important/, '').strip if el[html_att].nil? and not merged[css_att].empty?
+              merged.instance_variable_get("@declarations").tap do |declarations|
+                declarations.delete(css_att)
+              end
             end
           end
 

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -77,6 +77,9 @@ class Premailer
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name)
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               el[html_att] = merged[css_att].gsub(/url\(['|"](.*)['|"]\)/, '\1').gsub(/;$|\s*!important/, '').strip if el[html_att].nil? and not merged[css_att].empty?
+              merged.instance_variable_get("@declarations").tap do |declarations|
+                declarations.delete(css_att)
+              end
             end
           end
 

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -237,7 +237,8 @@ END_HTML
     premailer = Premailer.new(html, :with_html_string => true)
     premailer.to_inline_css
     assert_match /font-size: xx-large/, premailer.processed_doc.search('.style3').first.attributes['style'].to_s
-    assert_match /background: #000080/, premailer.processed_doc.search('.style5').first.attributes['style'].to_s
+    assert_no_match /background: #000080/, premailer.processed_doc.search('.style5').first.attributes['style'].to_s
+    assert_match /#000080/, premailer.processed_doc.search('.style5').first.attributes['bgcolor'].to_s
   end
 
   # in response to https://github.com/alexdunae/premailer/issues/56


### PR DESCRIPTION
Fixes #173 and removes other matched inline styles as well, not just `-premailer-` ones.