### PR TITLE
Support for local css file

### DIFF
--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -295,7 +295,7 @@ protected
 
           if tag.attributes['href'].to_s.include? @base_url.to_s and @html_file.kind_of?(String)
             if @options[:with_html_string]
-              link_uri = tag.attributes['href'].to_s.sub(@base_url.to_s, '').sub(/\A\/*/, '')
+              link_uri = tag.attributes['href'].to_s.sub(@base_url.to_s, '')
             else
               link_uri = File.join(File.dirname(@html_file), tag.attributes['href'].to_s.sub!(@base_url.to_s, ''))
               # if the file does not exist locally, try to grab the remote reference

--- a/lib/premailer/version.rb
+++ b/lib/premailer/version.rb
@@ -1,4 +1,4 @@
 class Premailer
   # Premailer version.
-  VERSION = '1.8.5'.freeze
+  VERSION = '1.8.6'.freeze
 end


### PR DESCRIPTION
Premailer should be able to use local css files (file paths, not urls). If the path is absolute, it starts with a '/' which was being removed.