### PR TITLE
Adds option to avoid shorthand creation

### DIFF
--- a/lib/premailer/adapter/hpricot.rb
+++ b/lib/premailer/adapter/hpricot.rb
@@ -75,7 +75,7 @@ class Premailer
           # Perform style folding
           merged = CssParser.merge(declarations)
           merged.expand_shorthand!
-          merged.create_shorthand!
+          merged.create_shorthand! if @options[:create_shorthands]
 
           # Duplicate CSS attributes as HTML attributes
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name)

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -17,7 +17,6 @@ class Premailer
         doc.search("*[@style]").each do |el|
           el['style'] = '[SPEC=1000[' + el.attributes['style'] + ']]'
         end
-
         # Iterate through the rules and merge them into the HTML
         @css_parser.each_selector(:all) do |selector, declaration, specificity, media_types|
           # Save un-mergable rules separately
@@ -79,9 +78,8 @@ class Premailer
               el[html_att] = merged[css_att].gsub(/url\(['|"](.*)['|"]\)/, '\1').gsub(/;$|\s*!important/, '').strip if el[html_att].nil? and not merged[css_att].empty?
             end
           end
-
           # Collapse multiple rules into one as much as possible.
-          merged.create_shorthand!
+          merged.create_shorthand! if @options[:create_shorthands]
 
           # write the inline STYLE attribute
           attributes = Premailer.escape_string(merged.declarations_to_s).split(';').map(&:strip)

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -173,6 +173,7 @@ class Premailer
   # @option options [Boolean] :escape_url_attributes URL Escapes href, src, and background attributes on elements. Default is true.
   # @option options [Symbol] :adapter Which HTML parser to use, either <tt>:nokogiri</tt> or <tt>:hpricot</tt>.  Default is <tt>:hpricot</tt>.
   # @option options [String] :output_encoding Output encoding option for Nokogiri adapter. Should be set to "US-ASCII" to output HTML entities instead of Unicode characters.
+  # @option options [Boolean] :create_shorthands Combine several properties into a shorthand one, e.g. font: style weight size. Default is true.
   def initialize(html, options = {})
     @options = {:warn_level => Warnings::SAFE,
                 :line_length => 65,
@@ -199,6 +200,7 @@ class Premailer
                 :replace_html_entities => false,
                 :escape_url_attributes => true,
                 :unescaped_ampersand => false,
+                :create_shorthands => true,
                 :adapter => Adapter.use,
                 }.merge(options)
 


### PR DESCRIPTION
In my case it's really useful to not create the shorthands since I'm using premailer to create html with inline style and then pass it to Docraptor to generate XLS files and docraptor don't support shorthand codes