### PR TITLE
Raise file not found exceptions if local file isn't found

### DIFF
--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -262,7 +262,9 @@ protected
       end
 
       load_css_from_string(css_block)
-    rescue; end
+    rescue => e
+      raise e if @options[:io_exceptions]
+    end
   end
 
   def load_css_from_string(css_string)


### PR DESCRIPTION
I feel like if io_exceptions are enabled, it should probably raise file not found exceptions for local CSS files... it could probably do with a test.

Thoughts? 

