### PR TITLE
Prevent insertion of spaces in data URLs

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -85,9 +85,13 @@ class Premailer
           merged.create_shorthand! if @options[:create_shorthands]
 
           # write the inline STYLE attribute
-          attributes = Premailer.escape_string(merged.declarations_to_s).split(';').map(&:strip)
-          attributes = attributes.map { |attr| [attr.split(':').first, attr] }.sort_by { |pair| pair.first }.map { |pair| pair[1] }
-          el['style'] = attributes.join('; ')
+          attributes = []
+          merged.each_declaration do |prop, val, is_important|
+           importance = is_important ? ' !important' : ''
+           attributes << [prop, "#{prop}: #{val}#{importance}"]
+          end
+          sorted = attributes.sort_by { |pair| pair.first }.collect { |pair| pair.last }
+          el['style'] = sorted.join('; ')
         end
 
         doc = write_unmergable_css_rules(doc, @unmergable_rules)

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -85,9 +85,13 @@ class Premailer
           merged.create_shorthand! if @options[:create_shorthands]
 
           # write the inline STYLE attribute
-          attributes = Premailer.escape_string(merged.declarations_to_s).split(';').map(&:strip)
-          attributes = attributes.map { |attr| [attr.split(':').first, attr] }.sort_by { |pair| pair.first }.map { |pair| pair[1] }
-          el['style'] = attributes.join('; ')
+          attributes = []
+          merged.each_declaration do |prop, val, is_important|
+           importance = is_important ? ' !important' : ''
+           attributes << [prop, "#{prop}: #{val}#{importance}"]
+          end
+          sorted = attributes.sort_by { |pair| pair.first }.collect { |pair| pair.last }
+          el['style'] = sorted.join('; ')
         end
 
         doc = write_unmergable_css_rules(doc, @unmergable_rules)

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -363,4 +363,13 @@ END_HTML
     end
   end
 
+  def test_data_uri
+    html = "<div id='backgrounded'></div>"
+    css = "#backgrounded { background: url(data:image/png;base64,iVBORw0K) }"
+    [:nokogiri, :nokogumbo, :hpricot].each do |adapter|
+      premailer = Premailer.new(html, :with_html_string => true, :css_string => css, :adapter => adapter)
+      assert_match Regexp.new(Regexp.escape('style="background: url(data:image/png;base64,iVBORw0K)')), premailer.to_inline_css, "Problem when using #{adapter} adapter"
+    end
+  end
+
 end


### PR DESCRIPTION
This is test case and a fix for the problem discovered in #204. When the Nokogiri / Nokogumbo adapters are used, an extra space gets between the media type (image/png) and the 'base64' declaration.

The problem is in the code that sorts declarations; it `split`s on semicolons indiscriminately. Instead of applying a regex to the final CSS for the sake of sorting, we can enumerate the declarations one by one to build up a sortable collection.

We could make this even cleaner by extracting common code from the Nokogiri and Nokogumbo adapters, or even by doing the sort in `CssParser::RuleSet`, but in this PR I'm trying to keep things relatively simple.

I do see some strange test DOCTYPE and entity-related failures with this change in place, but I haven't been able to figure out why this change would have any effect on them in the least. If someone can point me in the right direction, I'd be glad to attempt to fix those too.