### PR TITLE
Add missing semicolon to end of style lists.

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -87,7 +87,7 @@ class Premailer
           # write the inline STYLE attribute
           attributes = Premailer.escape_string(merged.declarations_to_s).split(';').map(&:strip)
           attributes = attributes.map { |attr| [attr.split(':').first, attr] }.sort_by { |pair| pair.first }.map { |pair| pair[1] }
-          el['style'] = attributes.join('; ')
+          el['style'] = attributes.join('; ') + ";"
         end
 
         doc = write_unmergable_css_rules(doc, @unmergable_rules)

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -87,7 +87,7 @@ class Premailer
           # write the inline STYLE attribute
           attributes = Premailer.escape_string(merged.declarations_to_s).split(';').map(&:strip)
           attributes = attributes.map { |attr| [attr.split(':').first, attr] }.sort_by { |pair| pair.first }.map { |pair| pair[1] }
-          el['style'] = attributes.join('; ')
+          el['style'] = attributes.join('; ') + ";"
         end
 
         doc = write_unmergable_css_rules(doc, @unmergable_rules)


### PR DESCRIPTION
 Style lists without an ending semicolon  sometimes break layouts in Outlook.com. This PR adds semicolons to the end of style lists in the Nokogiri and Nokogumbo adapters.