### PR TITLE
Simplify link regex

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -31,15 +31,7 @@ module HtmlToPlainText
     txt.gsub!(/<img.+?alt=\'([^\']*)\'[^>]*\>/i, '\1')
 
     # links
-    txt.gsub!(/<a\s.*?href=\"(mailto:)?([^\"]*)\"[^>]*>((.|\s)*?)<\/a>/i) do |s|
-      if $3.empty?
-        ''
-      else
-        $3.strip + ' ( ' + $2.strip + ' )'
-      end
-    end
-
-    txt.gsub!(/<a\s.*?href='(mailto:)?([^\']*)\'[^>]*>((.|\s)*?)<\/a>/i) do |s|
+    txt.gsub!(/<a\s.*?href=["'](mailto:)?([^"']*)["'][^>]*>((.|\s)*?)<\/a>/i) do |s|
       if $3.empty?
         ''
       else


### PR DESCRIPTION
The only difference between the two cases were for single and double quotes. E.g.

    <a href="/foo">bar</a>

    <a href='/foo'>bar</a>