### PR TITLE
Improving wrap when link or many spaces are on the breaking point

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -84,25 +84,25 @@ module HtmlToPlainText
     he = HTMLEntities.new
     txt = he.decode(txt)
 
+    # no more than two consecutive spaces
+    txt.gsub!(/ {2,}/, " ")
+
     txt = word_wrap(txt, line_length)
 
     # remove linefeeds (\r\n and \r -> \n)
     txt.gsub!(/\r\n?/, "\n")
 
     # strip extra spaces
-    txt.gsub!(/\302\240+/, " ") # non-breaking spaces -> spaces
+    txt.gsub!(/[ \t]*\302\240+[ \t]*/, " ") # non-breaking spaces -> spaces
     txt.gsub!(/\n[ \t]+/, "\n") # space at start of lines
     txt.gsub!(/[ \t]+\n/, "\n") # space at end of lines
 
     # no more than two consecutive newlines
     txt.gsub!(/[\n]{3,}/, "\n\n")
 
-    # no more than two consecutive spaces
-    txt.gsub!(/ {2,}/, " ")
-
     # the word messes up the parens
-    txt.gsub!(/\([ \n](http[^)]+)[\n ]\)/) do |s|
-      "( " + $1 + " )"
+    txt.gsub!(/\(([ \n])(http[^)]+)([\n ])\)/) do |s|
+      ($1 == "\n" ? $1 : '' ) + '( ' + $2 + ' )' + ($3 == "\n" ? $1 : '' )
     end
 
     txt.strip

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -114,6 +114,10 @@ END_HTML
     assert lens.max <= 20
   end
 
+  def test_wrapping_lines_with_spaces
+    assert_plaintext "Long line\nnew line", 'Long     line new line', nil ,10
+  end
+
   def test_img_alt_tags
     # ensure html imag tags that aren't self-closed are parsed,
     # along with accepting both '' and "" as attribute quotes
@@ -163,6 +167,9 @@ END_HTML
 
     # empty link gets dropped, and shouldn't run forever
     assert_plaintext(("This is some more text\n\n" * 14 + "This is some more text"), "<a href=\"test\"></a>#{"\n<p>This is some more text</p>" * 15}")
+
+    # links that go outside of line should wrap nicely
+    assert_plaintext "Long text before the actual link and then LINK TEXT \n( http://www.long.link ) and then more text that does not wrap", 'Long text before the actual link and then <a href="http://www.long.link"/>LINK TEXT</a> and then more text that does not wrap'
   end
 
   # see https://github.com/alexdunae/premailer/issues/72


### PR DESCRIPTION
This PR address two cases when wrapping is not working really well.

### Link case 
```
Long text before the actual link and then <a href="http://www.long.link"/>LINK TEXT</a> and  then more text that does not wrap
```
currently doesn't wrap because [this](https://github.com/premailer/premailer/blob/master/lib/premailer/html_to_plain_text.rb#L104) overrides any wrapping that happened. So you just get:
```
Long text before the actual link and then LINK TEXT ( http://www.long.link ) and then more text that does not wrap
```
while what should happen is:
```
Long text before the actual link and then LINK TEXT
( http://www.long.link ) and then more text that does not wrap
```

### Space case

In this case (consider line length of 10)
```
Long     line new line
```
Because the extra space goes over the line limit, wrapping will be wrongly done:
```
Long
line new
line
```
While the correct would be:
```
Long line
new line
```
To fix this I remove the extra double space before wrapping and also fix the only other place where the extra spaces could have been introduced after.