### PR TITLE
Do not repeat text if the anchor content is the same as the link

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -34,6 +34,8 @@ module HtmlToPlainText
     txt.gsub!(/<a\s.*?href=["'](mailto:)?([^"']*)["'][^>]*>((.|\s)*?)<\/a>/i) do |s|
       if $3.empty?
         ''
+      elsif $3.strip.downcase == $2.strip.downcase
+        $3.strip
       else
         $3.strip + ' ( ' + $2.strip + ' )'
       end

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -163,6 +163,9 @@ END_HTML
 
     # empty link gets dropped, and shouldn't run forever
     assert_plaintext(("This is some more text\n\n" * 14 + "This is some more text"), "<a href=\"test\"></a>#{"\n<p>This is some more text</p>" * 15}")
+
+    # same text and link
+    assert_plaintext 'http://example.com', '<a href="http://example.com">http://example.com</a>'
   end
 
   # see https://github.com/alexdunae/premailer/issues/72


### PR DESCRIPTION
When the text of the anchor is the same as the link (most often the case with email addresses), there is no need to repeat both.

```
<a href="mailto:mail@example.com">mail@example.com</a>
```
currently becomes 
```
mail@example.com ( mail@example.com )
```
Which is redundant. Now we could debate if the result should be with or without brackets. I prefer without  (and that's in this PR) because for the email it makes kind of sense. Brackets on the other hand do give it visibility. Still, brackets could result in strange cases when used in sentence. Eg:

```
Check it out at ( http://example.com )
```
instead a more simple
```
Check it out at http://example.com
```
