### PR TITLE
Fix for css with semicolon within brackets

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -85,7 +85,8 @@ class Premailer
           merged.create_shorthand! if @options[:create_shorthands]
 
           # write the inline STYLE attribute
-          attributes = Premailer.escape_string(merged.declarations_to_s).split(';').map(&:strip)
+          # split by ';' but ignore those in brackets
+          attributes = Premailer.escape_string(merged.declarations_to_s).split(/;(?![^(]*\))/).map(&:strip)
           attributes = attributes.map { |attr| [attr.split(':').first, attr] }.sort_by { |pair| pair.first }.map { |pair| pair[1] }
           el['style'] = attributes.join('; ') + ";"
         end

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -284,11 +284,7 @@ protected
 
     # Load CSS included in <tt>style</tt> and <tt>link</tt> tags from an HTML document.
   def load_css_from_html! # :nodoc:
-    if (@options[:adapter] == :nokogiri)
-      tags = @doc.search("link[@rel='stylesheet']:not([@data-premailer='ignore'])", "//style[not(contains(@data-premailer,'ignore'))]")
-    else
-      tags = @doc.search("link[@rel='stylesheet']:not([@data-premailer='ignore']), style:not([@data-premailer='ignore'])")
-    end
+    tags = @doc.search("link[@rel='stylesheet']:not([@data-premailer='ignore']), style:not([@data-premailer='ignore'])")
     if tags
       tags.each do |tag|
         if tag.to_s.strip =~ /^\<link/i && tag.attributes['href'] && media_type_ok?(tag.attributes['media']) && @options[:include_link_tags]

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -366,4 +366,39 @@ END_HTML
 
     assert !premailer.processed_doc.css('script[type="application/ld+json"]').first.children.first.cdata?
   end
+
+  def test_style_without_data_in_content
+    html = <<END_HTML
+    <html>
+    <head>
+      <style>#logo {content:url(good.png)};}</style>
+    </head>
+    <body>
+      <image id="logo"/>
+    </body>
+    </html>
+END_HTML
+    [:nokogiri, :hpricot].each do |adapter|
+      premailer = Premailer.new(html, :with_html_string => true, :adapter => adapter)
+      assert_match 'content: url(good.png)', premailer.to_inline_css
+    end
+  end
+
+  def test_style_with_data_in_content
+    html = <<END_HTML
+    <html>
+    <head>
+      <style>#logo {content: url(data:image/png;base64,LOTSOFSTUFF)};}</style>
+    </head>
+    <body>
+      <image id="logo"/>
+    </body>
+    </html>
+END_HTML
+    [:nokogiri, :hpricot].each do |adapter|
+      premailer = Premailer.new(html, :with_html_string => true, :adapter => adapter)
+      assert_match 'content: url(data:image/png;base64,LOTSOFSTUFF)', premailer.to_inline_css
+    end
+  end
+
 end


### PR DESCRIPTION
Some css has semicolon within brackets, e.g. the embedded image:
```
#logo {content: url(data:image/png;base64,LOTSOFSTUFF)};}
```

An improved split with regex solved that problem.
I also removed some code that block tests for ruby 2.2.2. The code looks unnecessary to me.