### PR TITLE
Remove Dialect copyright notices from CSS files

### DIFF
--- a/test/files/import.css
+++ b/test/files/import.css
@@ -1,8 +1,6 @@
 /*
  * Premailer styles - should import
  *
- * Copyright (c) 2009 Dialect Communications Group (dialect.ca)
- *
  * $Package: Premailer $
  * $Date: 2009-02-09 17:15:56 -0800 (Mon, 09 Feb 2009) $WCDATE$ $
  * $Rev: 95 $WCREV$ $

--- a/test/files/noimport.css
+++ b/test/files/noimport.css
@@ -1,8 +1,6 @@
 /*
  * Premailer styles - should not import
  *
- * Copyright (c) 2009 Dialect Communications Group (dialect.ca)
- *
  * $Package: Premailer $
  * $Date: 2009-02-09 17:15:56 -0800 (Mon, 09 Feb 2009) $WCDATE$ $
  * $Rev: 95 $WCREV$ $

--- a/test/files/styles.css
+++ b/test/files/styles.css
@@ -1,8 +1,6 @@
 /*
  * Premailer styles
  *
- * Copyright (c) 2009 Dialect Communications Group (dialect.ca)
- *
  * $Package: Premailer $
  * $Date: 2009-02-09 17:15:56 -0800 (Mon, 09 Feb 2009) $WCDATE$ $
  * $Rev: 95 $WCREV$ $
@@ -15,7 +13,7 @@
 body{font:13px/1.231 "Arial",sans-serif;color: #fff;background-color: #9EBF00;}
 
  #wrapper { width: 100%; margin: 2em 0; background-color: #9EBF00; color: #fff; }
- 
+
 .container { margin: 0 auto; line-height: 130%; color: #4d4d4d; text-align: left; }
 
 .frame { background-color: #b6d93f; font-size: 1px; line-height: 1px;  }


### PR DESCRIPTION
I’m the original creator of Premailer – I got a message today saying these copyright statements were problematic in packaging Premailer for Debian.

The CSS was always intended to be under the main project’s license.  These extra copyright notices can be removed to prevent any ambiguity. 

Cheers, Alex