### PR TITLE
Use input's own encoding if available

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,12 +31,14 @@ GEM
     json (1.8.3)
     maxitest (1.5.6)
       minitest (>= 5.0.0, < 5.9.0)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     minitest (5.8.4)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     nokogumbo (1.4.7)
       nokogiri
+    pkg-config (1.1.7)
     rake (0.9.6)
     redcarpet (3.3.4)
     safe_yaml (1.0.4)
@@ -72,3 +74,6 @@ DEPENDENCIES
   redcarpet (~> 3.0)
   webmock
   yard (~> 0.8.7.6)
+
+BUNDLED WITH
+   1.12.5

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -195,7 +195,7 @@ class Premailer
                 :io_exceptions => false,
                 :include_link_tags => true,
                 :include_style_tags => true,
-                :input_encoding => 'ASCII-8BIT',
+                :input_encoding => html.respond_to?(:encoding) ? html.encoding.to_s : 'ASCII-8BIT',
                 :output_encoding => nil,
                 :replace_html_entities => false,
                 :escape_url_attributes => true,


### PR DESCRIPTION
Ruby 1.9.1+ has the ability to guess the right input encoding to use via `String#encoding`.