### PR TITLE
Revert encoding change

### DIFF
--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -195,7 +195,7 @@ class Premailer
                 :io_exceptions => false,
                 :include_link_tags => true,
                 :include_style_tags => true,
-                :input_encoding => html.respond_to?(:encoding) ? html.encoding.to_s : 'ASCII-8BIT',
+                :input_encoding => 'ASCII-8BIT',
                 :output_encoding => nil,
                 :replace_html_entities => false,
                 :escape_url_attributes => true,

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -357,7 +357,7 @@ END_HTML
     html = ""
     css = "a:hover {color:red;}"
 
-    pm = Premailer.new(html, :with_html_string => true, :css_string => css, :adapter => :nokogiri)
+    pm = Premailer.new(html, :with_html_string => true, :css_string => css, :adapter => :nokogiri, input_encoding: 'UTF-8')
     pm.to_inline_css
   end
 


### PR DESCRIPTION
My prior PR may cause breaking changes to users of this library, and I don't want to cause encoding-related problems for people. The documentation for `:input_encoding` is clear enough to indicate that it should regularly be set when using this library and 'ASCII-8BIT' is a sane default. This change reverts my PR yesterday and patches the test to set the correct input encoding to silence the Nokogiri warnings.