### PR TITLE
Add Hpricot deprecation notice

### DIFF
--- a/lib/premailer/adapter/hpricot.rb
+++ b/lib/premailer/adapter/hpricot.rb
@@ -4,6 +4,13 @@ class Premailer
   module Adapter
     # Hpricot adapter
     module Hpricot
+      def self.included(base)
+        warn <<eos
+[DEPRECATED] Premailer's Hpricot adapter will be removed with the next major \
+release. Change your :adapter option to :nokogiri or remove the `hpricot` gem \
+from your application to silence this warning. (Called from #{caller[2]})
+eos
+      end
 
       # Merge CSS into the HTML document.
       # @return [String] HTML.


### PR DESCRIPTION
Adds a deprecation notice whenever the Hpricot adapter is included.

Message preview:

```
[DEPRECATED] Premailer's Hpricot adapter will be removed with the next major release. Change your :adapter option to :nokogiri or remove the `hpricot` gem from your application to silence this warning. (Called from premailer/test/test_warnings.rb:91:in `new')
```