### PR TITLE
Fix `remove_scripts` option

### DIFF
--- a/lib/premailer/executor.rb
+++ b/lib/premailer/executor.rb
@@ -45,7 +45,7 @@ opts = OptionParser.new do |opts|
   end
 
   opts.on("-j", "--remove-scripts", "Remove <script> elements") do |v|
-    options[:remove_classes] = v
+    options[:remove_scripts] = v
   end
 
   opts.on("-l", "--line-length N", Integer, "Line length for plaintext (default: #{options[:line_length].to_s})") do |v|


### PR DESCRIPTION
Typo in `executor.rb` means remove_scripts option wasn't working from the CLI