### PR TITLE
RGB to Hex Option

### DIFF
--- a/lib/premailer.rb
+++ b/lib/premailer.rb
@@ -5,5 +5,6 @@ require 'cgi'
 require 'css_parser'
 
 require 'premailer/adapter'
+require 'premailer/adapter/rgb_to_hex'
 require 'premailer/html_to_plain_text'
 require 'premailer/premailer'

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -4,7 +4,7 @@ class Premailer
   module Adapter
     # Nokogiri adapter
     module Nokogiri
-
+      include AdapterHelper::RgbToHex
       # Merge CSS into the HTML document.
       #
       # @return [String] an HTML.
@@ -75,7 +75,8 @@ class Premailer
           # Duplicate CSS attributes as HTML attributes
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name) && @options[:css_to_attributes]
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
-              el[html_att] = merged[css_att].gsub(/url\(['|"](.*)['|"]\)/, '\1').gsub(/;$|\s*!important/, '').strip if el[html_att].nil? and not merged[css_att].empty?
+              new_html_att = merged[css_att].gsub(/url\(['|"](.*)['|"]\)/, '\1').gsub(/;$|\s*!important/, '').strip if el[html_att].nil? and not merged[css_att].empty?
+              css_att.end_with?('color') && @options[:rgb_to_hex] ? el[html_att] = ensure_hex(new_html_att) : el[html_att] = new_html_att
               merged.instance_variable_get("@declarations").tap do |declarations|
                 declarations.delete(css_att)
               end

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -76,8 +76,10 @@ class Premailer
           # Duplicate CSS attributes as HTML attributes
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name) && @options[:css_to_attributes]
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
-              new_html_att = merged[css_att].gsub(/url\(['|"](.*)['|"]\)/, '\1').gsub(/;$|\s*!important/, '').strip if el[html_att].nil? and not merged[css_att].empty?
-              css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? el[html_att] = ensure_hex(new_html_att) : el[html_att] = new_html_att
+              if el[html_att].nil? and not merged[css_att].empty?
+                new_html_att = merged[css_att].gsub(/url\(['|"](.*)['|"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
+                el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att) : new_html_att
+              end
               merged.instance_variable_get("@declarations").tap do |declarations|
                 declarations.delete(css_att)
               end

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -4,6 +4,7 @@ class Premailer
   module Adapter
     # Nokogiri adapter
     module Nokogiri
+
       include AdapterHelper::RgbToHex
       # Merge CSS into the HTML document.
       #
@@ -76,7 +77,7 @@ class Premailer
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name) && @options[:css_to_attributes]
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               new_html_att = merged[css_att].gsub(/url\(['|"](.*)['|"]\)/, '\1').gsub(/;$|\s*!important/, '').strip if el[html_att].nil? and not merged[css_att].empty?
-              css_att.end_with?('color') && @options[:rgb_to_hex] ? el[html_att] = ensure_hex(new_html_att) : el[html_att] = new_html_att
+              css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? el[html_att] = ensure_hex(new_html_att) : el[html_att] = new_html_att
               merged.instance_variable_get("@declarations").tap do |declarations|
                 declarations.delete(css_att)
               end

--- a/lib/premailer/adapter/rgb_to_hex.rb
+++ b/lib/premailer/adapter/rgb_to_hex.rb
@@ -1,0 +1,31 @@
+# RGB helper for adapters, currently only nokogiri supported
+
+module AdapterHelper
+  module RgbToHex
+    def to_hex(str)
+      str.to_i.to_s(16).rjust(2, '0').upcase
+    end
+
+    def is_rgb?(color)
+      pattern = %r{
+      rgb
+      \(          # literal open
+      (\d{1,3})   # capture 1-3 digits
+      \s*,\s*     # comma, with optional whitespace
+      (\d{1,3})   # capture 1-3 digits
+      \s*,\s*     # comma, with optional whitespace
+      (\d{1,3})   # capture 1-3 digits
+      \)          # literal close
+      }x
+
+      pattern.match(color)
+    end
+
+    def ensure_hex(color)
+      match_data = is_rgb?(color)
+      if match_data
+        "#{to_hex(match_data[1])}#{to_hex(match_data[2])}#{to_hex(match_data[3])}"
+      end
+    end
+  end
+end

--- a/lib/premailer/adapter/rgb_to_hex.rb
+++ b/lib/premailer/adapter/rgb_to_hex.rb
@@ -9,13 +9,13 @@ module AdapterHelper
     def is_rgb?(color)
       pattern = %r{
       rgb
-      \(          # literal open
+      \(\s*    # literal open, with optional whitespace
       (\d{1,3})   # capture 1-3 digits
       \s*,\s*     # comma, with optional whitespace
       (\d{1,3})   # capture 1-3 digits
       \s*,\s*     # comma, with optional whitespace
       (\d{1,3})   # capture 1-3 digits
-      \)          # literal close
+      \s*\)       # literal close, with optional whitespace
       }x
 
       pattern.match(color)
@@ -25,6 +25,8 @@ module AdapterHelper
       match_data = is_rgb?(color)
       if match_data
         "#{to_hex(match_data[1])}#{to_hex(match_data[2])}#{to_hex(match_data[3])}"
+      else
+        color
       end
     end
   end

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -157,6 +157,7 @@ class Premailer
   # @option options [Array(String)] :css Manually specify CSS stylesheets.
   # @option options [Boolean] :css_to_attributes Copy related CSS attributes into HTML attributes (e.g. background-color to bgcolor)
   # @option options [String] :css_string Pass CSS as a string
+  # @option options [Boolean] :rgb_to_hex Convert RBG to Hex colors, default false
   # @option options [Boolean] :remove_ids Remove ID attributes whenever possible and convert IDs used as anchors to hashed to avoid collisions in webmail programs.  Default is false.
   # @option options [Boolean] :remove_classes Remove class attributes. Default is false.
   # @option options [Boolean] :remove_comments Remove html comments. Default is false.
@@ -180,6 +181,7 @@ class Premailer
                 :line_length => 65,
                 :link_query_string => nil,
                 :base_url => nil,
+                :rgb_to_hex => false,
                 :remove_classes => false,
                 :remove_ids => false,
                 :remove_comments => false,

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -157,7 +157,7 @@ class Premailer
   # @option options [Array(String)] :css Manually specify CSS stylesheets.
   # @option options [Boolean] :css_to_attributes Copy related CSS attributes into HTML attributes (e.g. background-color to bgcolor)
   # @option options [String] :css_string Pass CSS as a string
-  # @option options [Boolean] :rgb_to_hex Convert RBG to Hex colors, default false
+  # @option options [Boolean] :rgb_to_hex_attributes Convert RBG to Hex colors, default false
   # @option options [Boolean] :remove_ids Remove ID attributes whenever possible and convert IDs used as anchors to hashed to avoid collisions in webmail programs.  Default is false.
   # @option options [Boolean] :remove_classes Remove class attributes. Default is false.
   # @option options [Boolean] :remove_comments Remove html comments. Default is false.
@@ -181,7 +181,7 @@ class Premailer
                 :line_length => 65,
                 :link_query_string => nil,
                 :base_url => nil,
-                :rgb_to_hex => false,
+                :rgb_to_hex_attributes => true,
                 :remove_classes => false,
                 :remove_ids => false,
                 :remove_comments => false,

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -285,6 +285,22 @@ END_HTML
     end
   end
 
+  def test_rgb
+    html = <<-END_HTML
+    <html> <head> <style>table { background-color: rgb(250, 250, 250); } </style>
+    <body>
+    <table> <tr> <td> Test </td> </tr> </table>
+    </body> </html>
+    END_HTML
+
+    [:nokogiri].each do |adapter|
+      pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex => true, :adapter => adapter)
+      pm.to_inline_css
+      doc = pm.processed_doc
+      assert_equal 'FAFAFA', doc.at('table')['bgcolor']
+    end
+  end
+
   def test_include_link_tags_option
     local_setup('base.html', :adapter => :nokogiri, :include_link_tags => true)
     assert_match /1\.231/, @doc.at('body').attributes['style'].to_s

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -285,7 +285,7 @@ END_HTML
     end
   end
 
-  def test_rgb
+  def test_rgb_color
     html = <<-END_HTML
     <html> <head> <style>table { background-color: rgb(250, 250, 250); } </style>
     <body>
@@ -293,12 +293,25 @@ END_HTML
     </body> </html>
     END_HTML
 
-    [:nokogiri].each do |adapter|
-      pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex => true, :adapter => adapter)
-      pm.to_inline_css
-      doc = pm.processed_doc
-      assert_equal 'FAFAFA', doc.at('table')['bgcolor']
-    end
+    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex => true, :adapter => :nokogiri)
+    pm.to_inline_css
+    doc = pm.processed_doc
+    assert_equal 'FAFAFA', doc.at('table')['bgcolor']
+
+  end
+
+  def test_non_rgb_color
+    html = <<-END_HTML
+    <html> <head> <style>table { background-color:red; } </style>
+    <body>
+    <table> <tr> <td> Test </td> </tr> </table>
+    </body> </html>
+    END_HTML
+
+    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex => true, :adapter => :nokogiri)
+    pm.to_inline_css
+    doc = pm.processed_doc
+    assert_equal 'red', doc.at('table')['bgcolor']
   end
 
   def test_include_link_tags_option

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -293,7 +293,7 @@ END_HTML
     </body> </html>
     END_HTML
 
-    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex_attributes => true, :adapter => :nokogiri)
+    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex_attributes => true, :remove_scripts => true, :adapter => :nokogiri)
     pm.to_inline_css
     doc = pm.processed_doc
     assert_equal 'FAFAFA', doc.at('table')['bgcolor']

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -285,6 +285,21 @@ END_HTML
     end
   end
 
+  def test_empty_css_att
+    html = <<-END_HTML
+    <html> <head> <style>table { background-color: rgb(250, 250, 250); width: "550px"; } </style>
+    <body>
+    <table> <tr> <td> Test </td> </tr> </table>
+    </body> </html>
+    END_HTML
+
+    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex_attributes => true, :remove_scripts => true, :adapter => :nokogiri)
+    pm.to_inline_css
+    doc = pm.processed_doc
+
+    assert_equal '<table style="width: \'550px\';" bgcolor="FAFAFA"> <tr> <td> Test </td> </tr> </table>', doc.at('table').to_s
+  end
+
   def test_rgb_color
     html = <<-END_HTML
     <html> <head> <style>table { background-color: rgb(250, 250, 250); } </style>

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -293,7 +293,7 @@ END_HTML
     </body> </html>
     END_HTML
 
-    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex => true, :adapter => :nokogiri)
+    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex_attributes => true, :adapter => :nokogiri)
     pm.to_inline_css
     doc = pm.processed_doc
     assert_equal 'FAFAFA', doc.at('table')['bgcolor']
@@ -308,7 +308,7 @@ END_HTML
     </body> </html>
     END_HTML
 
-    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex => true, :adapter => :nokogiri)
+    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex_attributes => true, :adapter => :nokogiri)
     pm.to_inline_css
     doc = pm.processed_doc
     assert_equal 'red', doc.at('table')['bgcolor']


### PR DESCRIPTION
- Created to deal with rgb colors messing with our clients' email backgrounds
- Converts rgb colors to hex
- If color is not rgb it remains unchanged
- Includes tests
