### PR TITLE
Nokogiri Fast: Use HTML instead of HTML5

### DIFF
--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -223,10 +223,10 @@ class Premailer
         # However, we really don't want to hardcode this. ASCII-8BIT should be the default, but not the only option.
         if thing.is_a?(String) and RUBY_VERSION =~ /1.9/
           thing = thing.force_encoding(@options[:input_encoding]).encode!
-          doc = ::Nokogiri::HTML5(thing)
+          doc = ::Nokogiri::HTML(thing, nil, @options[:input_encoding]) { |c| c.recover }
         else
           default_encoding = RUBY_PLATFORM == 'java' ? nil : 'BINARY'
-          doc = ::Nokogiri::HTML5(thing)
+          doc = ::Nokogiri::HTML(thing, nil, @options[:input_encoding] || default_encoding) { |c| c.recover }
         end
 
         # Fix for removing any CDATA tags from both style and script tags inserted per


### PR DESCRIPTION
A minor change to the Nokogiri Fast adapter. I had earlier used the Nokogumbo's code instead of Nokogiri's. Can you please merge this change and bump the version ?

Thanks