### PR TITLE
Fix LoadError addressable with Addressable 2.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Premailer CHANGELOG
 
+### Version 1.10.2
+
+ * Fix LoadError addressable with Addressable 2.3.8
+
 ### Version 1.10.1
 
  * Depends on css_parser 1.4.10.

--- a/lib/premailer.rb
+++ b/lib/premailer.rb
@@ -2,7 +2,7 @@ require 'yaml'
 require 'open-uri'
 require 'digest/md5'
 require 'cgi'
-require 'addressable'
+require 'addressable/uri'
 require 'css_parser'
 
 require 'premailer/adapter'

--- a/lib/premailer/version.rb
+++ b/lib/premailer/version.rb
@@ -1,4 +1,4 @@
 class Premailer
   # Premailer version.
-  VERSION = '1.10.1'.freeze
+  VERSION = '1.10.2'.freeze
 end


### PR DESCRIPTION
Hi there,

I use the premailer gem v1.10.1 via the premailer-rails gem v1.9.5 and I also use the addressable gem v2.3.8.
I found an error when I executed the `bundle exec rake db:create` command.
I saw the following logs.

```
bundle exec rake db:create --trace

rake aborted!
LoadError: cannot load such file -- addressable
/home/ubuntu/liquid-pay-platform/vendor/bundle/ruby/2.3.0/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:293:in `require'
/home/ubuntu/liquid-pay-platform/vendor/bundle/ruby/2.3.0/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:293:in `block in require'
/home/ubuntu/liquid-pay-platform/vendor/bundle/ruby/2.3.0/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:259:in `load_dependency'
/home/ubuntu/liquid-pay-platform/vendor/bundle/ruby/2.3.0/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:293:in `require'
/home/ubuntu/liquid-pay-platform/vendor/bundle/ruby/2.3.0/gems/premailer-1.10.1/lib/premailer.rb:5:in `<top (required)>'
/home/ubuntu/liquid-pay-platform/vendor/bundle/ruby/2.3.0/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:293:in `require'
/home/ubuntu/liquid-pay-platform/vendor/bundle/ruby/2.3.0/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:293:in `block in require'
/home/ubuntu/liquid-pay-platform/vendor/bundle/ruby/2.3.0/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:259:in `load_dependency'
/home/ubuntu/liquid-pay-platform/vendor/bundle/ruby/2.3.0/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:293:in `require'
/home/ubuntu/liquid-pay-platform/vendor/bundle/ruby/2.3.0/gems/premailer-rails-1.9.5/lib/premailer/rails.rb:1:in `<top (required)>'
/home/ubuntu/.rvm/gems/ruby-2.3.3@global/gems/bundler-1.14.6/lib/bundler/runtime.rb:105:in `require'
/home/ubuntu/.rvm/gems/ruby-2.3.3@global/gems/bundler-1.14.6/lib/bundler/runtime.rb:105:in `rescue in block in require'
/home/ubuntu/.rvm/gems/ruby-2.3.3@global/gems/bundler-1.14.6/lib/bundler/runtime.rb:82:in `block in require'
/home/ubuntu/.rvm/gems/ruby-2.3.3@global/gems/bundler-1.14.6/lib/bundler/runtime.rb:75:in `each'
/home/ubuntu/.rvm/gems/ruby-2.3.3@global/gems/bundler-1.14.6/lib/bundler/runtime.rb:75:in `require'
/home/ubuntu/.rvm/gems/ruby-2.3.3@global/gems/bundler-1.14.6/lib/bundler.rb:107:in `require'
/home/ubuntu/liquid-pay-platform/config/application.rb:12:in `<top (required)>'
/home/ubuntu/liquid-pay-platform/Rakefile:4:in `require'
/home/ubuntu/liquid-pay-platform/Rakefile:4:in `<top (required)>'
```

The problem is the file loading.
Addressable gem v2.4.0 has the `lib/addressable.rb` file. Ref. https://github.com/sporkmonger/addressable/blob/addressable-2.4.0/lib
But Addressable gem v2.3.8 does not have `lib/addressable.rb` file. Ref. https://github.com/sporkmonger/addressable/tree/addressable-2.3.8/lib

If we need only `Addressable::URI` namespace, then loading the `addressable/uri` file is more preferable I think.
This PR will fix this problem.