### PR TITLE
comeback many whitespace

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -86,9 +86,6 @@ module HtmlToPlainText
     he = HTMLEntities.new
     txt = he.decode(txt)
 
-    # no more than two consecutive spaces
-    txt.gsub!(/ {2,}/, " ")
-
     txt = word_wrap(txt, line_length)
 
     # remove linefeeds (\r\n and \r -> \n)

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -114,8 +114,8 @@ END_HTML
     assert lens.max <= 20
   end
 
-  def test_wrapping_lines_with_spaces
-    assert_plaintext "Long line\nnew line", 'Long     line new line', nil ,10
+  def test_wrapping_lines_with_many_spaces
+    assert_plaintext "Long     line\nnext line", "Long     line next line", nil ,14
   end
 
   def test_img_alt_tags


### PR DESCRIPTION
Sometimes plain version needs many whitespaces: 
Look this issue https://github.com/premailer/premailer/issues/8

In my case (for example) it is necessary to cut off unnecessary text when previewing a letter in the general list.
