### PR TITLE
back whitespaces

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -86,9 +86,7 @@ module HtmlToPlainText
     he = HTMLEntities.new
     txt = he.decode(txt)
 
-    # no more than two consecutive spaces
-    txt.gsub!(/ {2,}/, " ")
-
+    # word wrap
     txt = word_wrap(txt, line_length)
 
     # remove linefeeds (\r\n and \r -> \n)

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -44,7 +44,7 @@ END_HTML
     assert_plaintext "a\na", "  \na \n a \t"
     assert_plaintext "a\n\na", "  \na \n\t \n \n a \t"
     assert_plaintext "test text", "test text&nbsp;"
-    assert_plaintext "test text", "test        text"
+    assert_plaintext "test        text", "test        text"
   end
 
   def test_wrapping_spans
@@ -114,8 +114,8 @@ END_HTML
     assert lens.max <= 20
   end
 
-  def test_wrapping_lines_with_spaces
-    assert_plaintext "Long line\nnew line", 'Long     line new line', nil ,10
+  def test_wrapping_lines_with_many_spaces
+    assert_plaintext "Long     line\nnext line", "Long     line next line", nil ,14
   end
 
   def test_img_alt_tags


### PR DESCRIPTION
Look at issue https://github.com/premailer/premailer/issues/8 ( Premailer should preserve HTML entities ) 
Nokogiri converts in actual chars, please do not remove actual chars!