### PR TITLE
Fix exponential regexp in convert_to_text

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -31,7 +31,7 @@ module HtmlToPlainText
     txt.gsub!(/<img.+?alt=\'([^\']*)\'[^>]*\>/i, '\1')
 
     # links
-    txt.gsub!(/<a\s.*?href=["'](mailto:)?([^"']*)["'][^>]*>((.|\s)*?)<\/a>/i) do |s|
+    txt.gsub!(/<a\s[^\n]*?href=["'](mailto:)?([^"']*)["'][^>]*>(.*?)<\/a>/im) do |s|
       if $3.empty?
         ''
       elsif $3.strip.downcase == $2.strip.downcase

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -188,6 +188,15 @@ END_HTML
                      "<h1><a href='http://example.com/'>Test</a></h1>"
   end
 
+  def test_unterminated_anchor_tag
+    assert_plaintext("Example -->", <<-HTML)
+            <th>
+          <!-- <a href="https://www.example.com">
+                Example -->
+            </th>
+    HTML
+  end
+
   def assert_plaintext(out, raw, msg = nil, line_length = 65)
     assert_equal out, convert_to_text(raw, line_length), msg
   end


### PR DESCRIPTION
I suspect the the fact that the dot and the \s were overlapping for characters such as the space caused the regexp engine to try to match a long string of spaces with every permutation of both possibilities.