### PR TITLE
Fix input encoding in Nokogiri adapters

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -226,7 +226,7 @@ class Premailer
           thing = thing.force_encoding(@options[:input_encoding]).encode!
           @options[:input_encoding]
         else
-          @options[:input_encoding] || RUBY_PLATFORM == 'java' ? nil : 'BINARY'
+          @options[:input_encoding] || (RUBY_PLATFORM == 'java' ? nil : 'BINARY')
         end
         doc = if @options[:html_fragment]
           ::Nokogiri::HTML.fragment(thing, encoding)

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -228,7 +228,7 @@ class Premailer
           thing = thing.force_encoding(@options[:input_encoding]).encode!
           @options[:input_encoding]
         else
-          @options[:input_encoding] || RUBY_PLATFORM == 'java' ? nil : 'BINARY'
+          @options[:input_encoding] || (RUBY_PLATFORM == 'java' ? nil : 'BINARY')
         end
         doc = if @options[:html_fragment]
           ::Nokogiri::HTML.fragment(thing, encoding)


### PR DESCRIPTION
The bug was introduced in #350 and it's related to operator precedence. 

This caused the option `:input_encoding` to be ignored.