### PR TITLE
For outlook 2013/2016 compatibility (on Win7)

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -13,6 +13,16 @@ class Premailer
         doc = @processed_doc
         @unmergable_rules = CssParser::Parser.new
 
+        doc.search("img").each do |el|
+          number_attr_reg = /\:[\'\"]?(\d+)/
+          if el['style'] =~ /width#{number_attr_reg}/
+            el.set_attribute('width', $~[1])
+          end
+          if el['style'] =~ /height#{number_attr_reg}/
+            el.set_attribute('height', $~[1])
+          end
+        end
+
         # Give all styles already in style attributes a specificity of 1000
         # per http://www.w3.org/TR/CSS21/cascade.html#specificity
         doc.search("*[@style]").each do |el|

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -14,7 +14,7 @@ class Premailer
         @unmergable_rules = CssParser::Parser.new
 
         doc.search("img").each do |el|
-          number_attr_reg = /:[\'\"]?(\d+)/
+          number_attr_reg = /:\s*[\'\"]?(\d+)/
           if el['style'] =~ /width#{number_attr_reg}/
             el.set_attribute('width', $~[1])
           end

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -14,11 +14,12 @@ class Premailer
         @unmergable_rules = CssParser::Parser.new
 
         doc.search("img").each do |el|
+          none_id = /(?<![\w\-])/
           number_attr_reg = /:\s*[\'\"]?(\d+)/
-          if el['style'] =~ /width#{number_attr_reg}/
+          if el['style'] =~ /#{none_id}width#{number_attr_reg}/
             el.set_attribute('width', $~[1])
           end
-          if el['style'] =~ /height#{number_attr_reg}/
+          if el['style'] =~ /#{none_id}height#{number_attr_reg}/
             el.set_attribute('height', $~[1])
           end
           if el['width'] =~ /\d+/

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -14,12 +14,18 @@ class Premailer
         @unmergable_rules = CssParser::Parser.new
 
         doc.search("img").each do |el|
-          number_attr_reg = /\:[\'\"]?(\d+)/
+          number_attr_reg = /:[\'\"]?(\d+)/
           if el['style'] =~ /width#{number_attr_reg}/
             el.set_attribute('width', $~[1])
           end
           if el['style'] =~ /height#{number_attr_reg}/
             el.set_attribute('height', $~[1])
+          end
+          if el['width'] =~ /\d+/
+            el.set_attribute('width', $~)
+          end
+          if el['height'] =~ /\d+/
+            el.set_attribute('height', $~)
           end
         end
 

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -234,7 +234,7 @@ class Premailer
       :io_exceptions => @options[:io_exceptions]
     })
 
-    @adapter_class = Adapter.find :nokogiri #@options[:adapter]
+    @adapter_class = Adapter.find @options[:adapter]
 
     self.class.send(:include, @adapter_class)
 

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -234,7 +234,7 @@ class Premailer
       :io_exceptions => @options[:io_exceptions]
     })
 
-    @adapter_class = Adapter.find @options[:adapter]
+    @adapter_class = Adapter.find :nokogiri #@options[:adapter]
 
     self.class.send(:include, @adapter_class)
 

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -3,11 +3,6 @@
 require File.expand_path(File.dirname(__FILE__)) + '/helper'
 
 class TestPremailer < Premailer::TestCase
-    # tests are order dependent
-  def self.test_order
-    :alpha
-  end
-
   def test_special_characters_nokogiri
     html = 	'<p>cédille c&eacute; & garçon gar&#231;on à &agrave; &nbsp; &amp; &copy;</p>'
     premailer = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri)

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -398,6 +398,18 @@ END_HTML
     assert_equal '100', premailer.processed_doc.at('img')["height"]
   end
 
+  def test_img_with_dimensional_style_should_have_html_dimension_attribute_with_no_unit
+    html = <<-END_HTML
+    <img src="aa.jpg" width="100px" height="40px"></img>
+    END_HTML
+
+    premailer = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri)
+    premailer.to_inline_css
+    assert_equal '100', premailer.processed_doc.at('img')["width"]
+    assert_equal '40', premailer.processed_doc.at('img')["height"]
+  end
+
+
 
   def silence_stderr(&block)
     orig_stderr = $stderr

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -3,6 +3,11 @@
 require File.expand_path(File.dirname(__FILE__)) + '/helper'
 
 class TestPremailer < Premailer::TestCase
+    # tests are order dependent
+  def self.test_order
+    :alpha
+  end
+
   def test_special_characters_nokogiri
     html = 	'<p>cédille c&eacute; & garçon gar&#231;on à &agrave; &nbsp; &amp; &copy;</p>'
     premailer = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri)
@@ -381,6 +386,18 @@ END_HTML
     pm = Premailer.new(html, :with_html_string => true, :css_string => css, :adapter => :nokogiri, input_encoding: 'UTF-8')
     pm.to_inline_css
   end
+
+  def test_img_with_dimensional_style_should_have_html_dimension_attribute_too__for_old_outlook_compatibility
+    html = <<-END_HTML
+    <img src="aa.jpg" style="width:70px;height:'100px'"></img>
+    END_HTML
+
+    premailer = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri)
+    premailer.to_inline_css
+    assert_equal '70', premailer.processed_doc.at('img')["width"]
+    assert_equal '100', premailer.processed_doc.at('img')["height"]
+  end
+
 
   def silence_stderr(&block)
     orig_stderr = $stderr


### PR DESCRIPTION
Dimensions for img in Inline css style doesn't work for outlook 2013/16 on Windows.
Also, dimension attributes (width, height) for img with unit (px) doesn't work.

This pull request will extract the width and height from the inline css and set them to html attributes with no unit.