### PR TITLE
Fix a case where img alt detection could cause real content to be deleted if there was an img tag without alt on the same line as one with alt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ source "https://rubygems.org"
 
 gem 'css_parser', :git => 'https://github.com/premailer/css_parser.git'
 
+group :development, :test do
+  gem 'rspec-core'
+end
+
 platforms :jruby do
   gem 'jruby-openssl'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,9 @@ GEM
     public_suffix (3.0.1)
     rake (12.2.1)
     redcarpet (3.4.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
     safe_yaml (1.0.4)
     simplecov (0.14.1)
       docile (~> 1.1.0)
@@ -71,8 +74,9 @@ DEPENDENCIES
   premailer!
   rake (> 0.8, != 0.9.0)
   redcarpet (~> 3.0)
+  rspec-core
   webmock
   yard
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -21,14 +21,14 @@ module HtmlToPlainText
     # eg. the following formats:
     # <img alt="" />
     # <img alt="">
-    txt.gsub!(/<img.+?alt=\"([^\"]*)\"[^>]*\>/i, '\1')
+    txt.gsub!(/<img[^>]+?alt=\"([^\"]*)\"[^>]*\>/i, '\1')
 
     # for img tags with '' for attribute quotes
     # with or without closing tag
     # eg. the following formats:
     # <img alt='' />
     # <img alt=''>
-    txt.gsub!(/<img.+?alt=\'([^\']*)\'[^>]*\>/i, '\1')
+    txt.gsub!(/<img[^>]+?alt=\'([^\']*)\'[^>]*\>/i, '\1')
 
     # links
     txt.gsub!(/<a\s[^\n]*?href=["'](mailto:)?([^"']*)["'][^>]*>(.*?)<\/a>/im) do |s|

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -130,6 +130,10 @@ END_HTML
     assert_plaintext 'Example ( http://example.com/ )', "<a href='http://example.com/'><img src='http://example.ru/hello.jpg' alt='Example'/></a>"
     # <img alt=''>
     assert_plaintext 'Example ( http://example.com/ )', "<a href='http://example.com/'><img src='http://example.ru/hello.jpg' alt='Example'></a>"
+    # <img /> a60cc657c190b6f4cdb83ebe9f1c5bfad <img alt=\"\"> ae48b4c58d668b8ce5bd80bbe2cc28237
+    assert_plaintext "a60cc657c190b6f4cdb83ebe9f1c5bfad\nae48b4c58d668b8ce5bd80bbe2cc28237", "<img /> a60cc657c190b6f4cdb83ebe9f1c5bfad <img alt=\"\"> ae48b4c58d668b8ce5bd80bbe2cc28237"
+    # <img> a60cc657c190b6f4cdb83ebe9f1c5bfad <img alt=\"\"> ae48b4c58d668b8ce5bd80bbe2cc28237
+    assert_plaintext "a60cc657c190b6f4cdb83ebe9f1c5bfad\nae48b4c58d668b8ce5bd80bbe2cc28237", "<img> a60cc657c190b6f4cdb83ebe9f1c5bfad <img alt=\"\"> ae48b4c58d668b8ce5bd80bbe2cc28237"
   end
 
   def test_links


### PR DESCRIPTION
See the spec change for the situation that this fixes.