### PR TITLE
Add -premailer-align CSS attribute to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Premailer looks for a few CSS attributes that make working with tables a bit eas
 | -premailer-height | Available on `table`, `tr`, `th` and `td` elements |
 | -premailer-cellpadding | Available on `table` elements |
 | -premailer-cellspacing | Available on `table` elements |
+| -premailer-align | Available on `table` elements |
 | data-premailer="ignore" | Available on `link` and `style` elements. Premailer will ignore these elements entirely. |
 
 Each of these CSS declarations will be copied to appropriate element's attribute.


### PR DESCRIPTION
#365 Think others would find it useful to know about the -premailer-align attribute without reviewing the source.