### PR TITLE
Plaintext documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ script is my solution.
   - Checks links in `href`, `src` and CSS `url('')`
 * CSS properties are checked against e-mail client capabilities
   - Based on the Email Standards Project's guides
-* A plain text version is created (optional)
+* A [plain text version](https://premailer.github.io/premailer/HtmlToPlainText.html) is created (optional)
 
 ## Installation
 

--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -5,6 +5,11 @@ require 'htmlentities'
 module HtmlToPlainText
 
   # Returns the text in UTF-8 format with all HTML tags removed
+  #   
+  # HTML content can be omitted from the output by surrounding it in the following comments:   
+  #
+  # <!-- start text/html -->
+  # <!-- end text/html -->
   #
   # TODO: add support for DL, OL
   def convert_to_text(html, line_length = 65, from_charset = 'UTF-8')


### PR DESCRIPTION
This PR adds documentation for the annotations that can be added to HTML to omit sections in the plaintext output. We've been using this Gem for nearly 2 years, but only became aware we could do this once I looked at the source. Thanks for creating a great library 😄 .