### PR TITLE
Remove deprecated has_rdoc

### DIFF
--- a/premailer.gemspec
+++ b/premailer.gemspec
@@ -5,7 +5,6 @@ Gem::Specification.new "premailer", Premailer::VERSION do |s|
   s.email    = "akzhan.abdulin@gmail.com"
   s.homepage = "https://github.com/premailer/premailer"
   s.description = "Improve the rendering of HTML emails by making CSS inline, converting links and warning about unsupported code."
-  s.has_rdoc = true
   s.author  = "Alex Dunae"
   s.files            = `git ls-files lib misc LICENSE.md README.md`.split("\n")
   s.executables      = ['premailer']
@@ -25,4 +24,3 @@ Gem::Specification.new "premailer", Premailer::VERSION do |s|
   s.add_development_dependency('webmock')
   s.add_development_dependency('nokogumbo')
 end
-


### PR DESCRIPTION
When I bundle I am getting this warning:

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/stefan/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/bundler/gems/premailer-875bbeb9f6d2/premailer.gemspec:8.
```

This should fix it. Thanks!
