### PR TITLE
Get all unit tests passing again (by fixing a number of interrelated issues)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ branches:
   only: master
 matrix:
   fast_finish: true
-before_install: rm Gemfile.lock
 language: ruby
 rvm:
   - 2.1.9

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -226,9 +226,9 @@ class Premailer
           thing = thing.force_encoding(@options[:input_encoding]).encode!
         end
         doc = if @options[:html_fragment]
-          ::Nokogiri::HTML5(thing)
-        else
           ::Nokogiri::HTML5.fragment(thing)
+        else
+          ::Nokogiri::HTML5(thing)
         end
 
         # Fix for removing any CDATA tags from both style and script tags inserted per

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -236,7 +236,7 @@ class Premailer
 
     @adapter_class = Adapter.find @options[:adapter]
 
-    self.class.send(:include, @adapter_class)
+    self.extend(@adapter_class)
 
     @doc = load_html(@html_file)
 

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -5,7 +5,7 @@ class TestHtmlToPlainText < Premailer::TestCase
   include HtmlToPlainText
 
   def test_to_plain_text_with_fragment
-    premailer = Premailer.new('<p>Test</p>', :with_html_string => true)
+    premailer = Premailer.new('<p>Test</p>', :adapter => :nokogiri, :with_html_string => true)
     assert_match /Test/, premailer.to_plain_text
   end
 
@@ -19,7 +19,7 @@ class TestHtmlToPlainText < Premailer::TestCase
 		</html>
 END_HTML
 
-    premailer = Premailer.new(html, :with_html_string => true)
+    premailer = Premailer.new(html, :adapter => :nokogiri, :with_html_string => true)
     assert_match /Test/, premailer.to_plain_text
   end
 
@@ -31,7 +31,7 @@ END_HTML
 		<p>Test
 END_HTML
 
-    premailer = Premailer.new(html, :with_html_string => true)
+    premailer = Premailer.new(html, :adapter => :nokogiri, :with_html_string => true)
     assert_match /Test/, premailer.to_plain_text
   end
 
@@ -56,7 +56,7 @@ END_HTML
 		</p>
 END_HTML
 
-    premailer = Premailer.new(html, :with_html_string => true)
+    premailer = Premailer.new(html, :adapter => :nokogiri, :with_html_string => true)
     assert_match /Test line 2/, premailer.to_plain_text
   end
 
@@ -82,7 +82,7 @@ END_HTML
     <!-- end text/html -->
     <p>text</p>
 END_HTML
-    premailer = Premailer.new(html, :with_html_string => true)
+    premailer = Premailer.new(html, :adapter => :nokogiri, :with_html_string => true)
     assert_match /test\n\ntext/, premailer.to_plain_text
   end
 

--- a/test/test_links.rb
+++ b/test/test_links.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__)) + '/helper'
 
 class TestLinks < Premailer::TestCase
   def test_empty_query_string
-    premailer = Premailer.new('<p>Test</p>', :with_html_string => true, :link_query_string => ' ')
+    premailer = Premailer.new('<p>Test</p>', :adapter => :nokogiri, :with_html_string => true, :link_query_string => ' ')
     premailer.to_inline_css
   end
 
@@ -62,14 +62,14 @@ class TestLinks < Premailer::TestCase
   def test_stripping_extra_question_marks_from_query_string
     qs = '??utm_source=1234'
 
-    premailer = Premailer.new("<a href='/test/?'>Link</a> <a href='/test/'>Link</a>", :link_query_string => qs, :with_html_string => true)
+    premailer = Premailer.new("<a href='/test/?'>Link</a> <a href='/test/'>Link</a>", :adapter => :nokogiri, :link_query_string => qs, :with_html_string => true)
     premailer.to_inline_css
 
     premailer.processed_doc.search('a').each do |a|
       assert_equal '/test/?utm_source=1234', a['href'].to_s
     end
 
-    premailer = Premailer.new("<a href='/test/?123&456'>Link</a>", :link_query_string => qs, :with_html_string => true)
+    premailer = Premailer.new("<a href='/test/?123&456'>Link</a>", :adapter => :nokogiri, :link_query_string => qs, :with_html_string => true)
     premailer.to_inline_css
 
     assert_equal '/test/?123&456&amp;utm_source=1234', premailer.processed_doc.at('a')['href']
@@ -78,7 +78,7 @@ class TestLinks < Premailer::TestCase
   def test_unescape_ampersand
     qs = 'utm_source=1234'
 
-    premailer = Premailer.new("<a href='/test/?q=query'>Link</a>", :link_query_string => qs, :with_html_string => true, :unescaped_ampersand => true)
+    premailer = Premailer.new("<a href='/test/?q=query'>Link</a>", :adapter => :nokogiri, :link_query_string => qs, :with_html_string => true, :unescaped_ampersand => true)
     premailer.to_inline_css
 
     premailer.processed_doc.search('a').each do |a|
@@ -88,13 +88,13 @@ class TestLinks < Premailer::TestCase
 
   def test_preserving_links
     html = "<a href='http://example.com/index.php?pram1=one&pram2=two'>Link</a>"
-    premailer = Premailer.new(html.to_s, :link_query_string => '', :with_html_string => true)
+    premailer = Premailer.new(html.to_s, :adapter => :nokogiri, :link_query_string => '', :with_html_string => true)
     premailer.to_inline_css
 
     assert_equal 'http://example.com/index.php?pram1=one&pram2=two', premailer.processed_doc.at('a')['href']
 
     html = "<a href='http://example.com/index.php?pram1=one&pram2=two'>Link</a>"
-    premailer = Premailer.new(html.to_s, :link_query_string => 'qs', :with_html_string => true)
+    premailer = Premailer.new(html.to_s, :adapter => :nokogiri, :link_query_string => 'qs', :with_html_string => true)
     premailer.to_inline_css
 
     assert_equal 'http://example.com/index.php?pram1=one&pram2=two&amp;qs', premailer.processed_doc.at('a')['href']
@@ -166,7 +166,7 @@ class TestLinks < Premailer::TestCase
     ]
 
     html = convertable.collect {|url| "<a href='#{url}'>Link</a>" }
-    premailer = Premailer.new(html.to_s, :base_url => "http://example.com", :with_html_string => true)
+    premailer = Premailer.new(html.to_s, :adapter => :nokogiri, :base_url => "http://example.com", :with_html_string => true)
 
     premailer.processed_doc.search('a').each do |el|
       href = el.attributes['href'].to_s
@@ -192,7 +192,7 @@ class TestLinks < Premailer::TestCase
 
     html = not_convertable.collect {|url| "<a href='#{url}'>Link</a>" }
 
-    premailer = Premailer.new(html.to_s, :base_url => "example.com", :with_html_string => true)
+    premailer = Premailer.new(html.to_s, :adapter => :nokogiri, :base_url => "example.com", :with_html_string => true)
     premailer.to_inline_css
 
     premailer.processed_doc.search('a').each do |el|

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -16,7 +16,7 @@ class TestMisc < Premailer::TestCase
 		</html>
 END_HTML
 
-    premailer = Premailer.new(html, :with_html_string => true)
+    premailer = Premailer.new(html, :adapter => :nokogiri, :with_html_string => true)
     premailer.to_inline_css
 
     assert_match /color\:\s*red/i,  premailer.processed_doc.at('p')['style']
@@ -32,7 +32,7 @@ END_HTML
 		</html>
 END_HTML
 
-    premailer = Premailer.new(html, :with_html_string => true)
+    premailer = Premailer.new(html, :adapter => :nokogiri, :with_html_string => true)
     premailer.to_inline_css
 
     assert_match /color\:\s*red/i,  premailer.processed_doc.at('p')['style']
@@ -76,7 +76,7 @@ END_HTML
 		</html>
     END_HTML
 
-    premailer = Premailer.new(html, :with_html_string => true)
+    premailer = Premailer.new(html, :adapter => :nokogiri, :with_html_string => true)
     premailer.to_inline_css
     premailer.processed_doc.search('p').each do |el|
       assert_match /red/i, el['style']
@@ -121,7 +121,7 @@ END_HTML
 		</body> </html>
 END_HTML
 
-    premailer = Premailer.new(html, :with_html_string => true, :verbose => true)
+    premailer = Premailer.new(html, :adapter => :nokogiri, :with_html_string => true, :verbose => true)
     premailer.to_inline_css
 
     # blue should be inlined
@@ -175,7 +175,7 @@ END_HTML
 		</html>
 END_HTML
 
-    premailer = Premailer.new(html, :with_html_string => true)
+    premailer = Premailer.new(html, :adapter => :nokogiri, :with_html_string => true)
     premailer.to_inline_css
     assert_match /a\:hover[\s]*\{[\s]*color\:[\s]*red;[\s]*\}/i, premailer.processed_doc.at('style').inner_html
   end
@@ -191,7 +191,7 @@ END_HTML
 		</html>
 END_HTML
 
-    premailer = Premailer.new(html, :with_html_string => true)
+    premailer = Premailer.new(html, :adapter => :nokogiri, :with_html_string => true)
     premailer.to_inline_css
     assert_match /color: red/, premailer.processed_doc.at('a').attributes['style'].to_s
   end
@@ -217,7 +217,7 @@ END_HTML
     </tr>
 END_HTML
 
-    premailer = Premailer.new(html, :with_html_string => true)
+    premailer = Premailer.new(html, :adapter => :nokogiri, :with_html_string => true)
     premailer.to_inline_css
     assert_match /font-size: xx-large/, premailer.processed_doc.search('.style3').first.attributes['style'].to_s
     refute_match /background: #000080/, premailer.processed_doc.search('.style5').first.attributes['style'].to_s
@@ -244,6 +244,7 @@ END_HTML
 
     premailer = Premailer.new(
       html,
+      adapter: :nokogiri,
       with_html_string: true,
       preserve_style_attribute: true
     )
@@ -292,7 +293,7 @@ END_HTML
     </html>
 END_HTML
 
-    premailer = Premailer.new(html, :with_html_string => true)
+    premailer = Premailer.new(html, :adapter => :nokogiri, :with_html_string => true)
     premailer.to_inline_css
 
     assert_match /margin: 0 auto/, premailer.processed_doc.search('#page').first.attributes['style'].to_s

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -150,7 +150,7 @@ END_HTML
     assert !Premailer.local_data?( 'http://example.com/path/' )
 
     # the old way is deprecated but should still work
-    premailer = Premailer.new( StringIO.new('a') )
+    premailer = Premailer.new( StringIO.new('a'), :adapter => :nokogiri )
     silence_stderr do
       assert premailer.local_uri?( '/path/' )
     end
@@ -370,7 +370,7 @@ END_HTML
     files_base = File.expand_path(File.dirname(__FILE__)) + '/files/'
     html_string = IO.read(File.join(files_base, 'html_with_uri.html'))
 
-    premailer = Premailer.new(html_string, :with_html_string => true)
+    premailer = Premailer.new(html_string, :adapter => :nokogiri, :with_html_string => true)
     premailer.to_inline_css
   end
 

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -100,7 +100,7 @@ END_HTML
 
   def test_css_to_attributes
     [:nokogiri, :nokogiri_fast, :nokogumbo].each do |adapter|
-      html = '<td style="background-color: #FFF;"></td>'
+      html = '<table><td style="background-color: #FFF;"></td></table>'
       premailer = Premailer.new(html, {:with_html_string => true, :adapter => adapter, :css_to_attributes => true})
       premailer.to_inline_css
       assert_equal '', premailer.processed_doc.search('td').first.attributes['style'].to_s
@@ -110,7 +110,7 @@ END_HTML
 
   def test_avoid_changing_css_to_attributes
     [:nokogiri, :nokogiri_fast, :nokogumbo].each do |adapter|
-      html = '<td style="background-color: #FFF;"></td>'
+      html = '<table><td style="background-color: #FFF;"></td></table>'
       premailer = Premailer.new(html, {:with_html_string => true, :adapter => adapter, :css_to_attributes => false})
       premailer.to_inline_css
       assert_match /background-color: #FFF/, premailer.processed_doc.at_css('td').attributes['style'].to_s

--- a/test/test_warnings.rb
+++ b/test/test_warnings.rb
@@ -88,7 +88,7 @@ END_HTML
 
 protected
   def get_warnings(html, adapter = :nokogiri, warn_level = Premailer::Warnings::SAFE)
-    pm = Premailer.new(html, {:adpater => adapter, :with_html_string => true, :warn_level => warn_level})
+    pm = Premailer.new(html, {:adapter => adapter, :with_html_string => true, :warn_level => warn_level})
     pm.to_inline_css
     pm.check_client_support
   end


### PR DESCRIPTION
This PR gets all the tests passing again and going green on travis-ci. It does this by fixing a number of interrelated issues:
* Change to the way the adapter is loaded into premailer so it's done on a per-instance basis rather than globally.
* Always set the adapter in the unit tests (rather than depending on the defaults) to stop the results of the tests being order dependent.
* The html_fragment option was doing exactly the opposite of what it was supposed to do for the nokogumbo adapter
* A small fix to one of the tests to make slightly more valid html so the html5 parser in nokogumbo wouldn't throw away the result
* Also, to ensure the build on travis-ci is the same as your local development copy this PR removes the line in .travis.yml which removes the Gemfile.lock file. Now, if you want to use more recent gems then `bundle update` and commit the changes.

I'm keen to do whatever you need to help get this merged