### PR TITLE
add option to drop unused css styles

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -94,7 +94,7 @@ class Premailer
           el['style'] = merged.declarations_to_s
         end
 
-        doc = write_unmergable_css_rules(doc, @unmergable_rules)
+        doc = write_unmergable_css_rules(doc, @unmergable_rules) unless @options[:drop_unmergeable_css_rules]
 
         if @options[:remove_classes] or @options[:remove_comments]
           doc.traverse do |el|

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -96,7 +96,7 @@ class Premailer
           el['style'] = merged.declarations_to_s
         end
 
-        doc = write_unmergable_css_rules(doc, @unmergable_rules)
+        doc = write_unmergable_css_rules(doc, @unmergable_rules) unless @options[:drop_unmergeable_css_rules]
 
         if @options[:remove_classes] or @options[:remove_comments]
           doc.traverse do |el|

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -94,7 +94,7 @@ class Premailer
           el['style'] = merged.declarations_to_s
         end
 
-        doc = write_unmergable_css_rules(doc, @unmergable_rules)
+        doc = write_unmergable_css_rules(doc, @unmergable_rules) unless @options[:drop_unmergeable_css_rules]
 
         if @options[:remove_classes] or @options[:remove_comments]
           doc.traverse do |el|

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -178,6 +178,7 @@ class Premailer
   # @option options [String] :output_encoding Output encoding option for Nokogiri adapter. Should be set to "US-ASCII" to output HTML entities instead of Unicode characters.
   # @option options [Boolean] :create_shorthands Combine several properties into a shorthand one, e.g. font: style weight size. Default is true.
   # @option options [Boolean] :html_fragment Handle HTML fragment without any HTML content wrappers. Default is false.
+  # @option options [Boolean] :drop_unmergeable_css_rules Do not include unmergeable css rules in a <tt><style><tt> tag. Default is false.  
   def initialize(html, options = {})
     @options = {:warn_level => Warnings::SAFE,
                 :line_length => 65,
@@ -209,6 +210,7 @@ class Premailer
                 :create_shorthands => true,
                 :html_fragment => false,
                 :adapter => Adapter.use,
+                :drop_unmergeable_css_rules => false
                 }.merge(options)
 
     @html_file = html

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -130,6 +130,21 @@ END_HTML
     assert_match /a\:hover[\s]*\{[\s]*color\:[\s]*red;[\s]*\}/i, premailer.processed_doc.at('head style').inner_html
   end
 
+
+  def test_drop_unmergable_rules
+    html = <<END_HTML
+    <html> <head> <style type="text/css"> a { color:blue; } a:hover { color: red; } </style> </head>
+    <p><a>Test</a></p>
+    </body> </html>
+END_HTML
+
+    premailer = Premailer.new(html, :with_html_string => true, :verbose => true, :drop_unmergeable_css_rules => true)
+    premailer.to_inline_css
+
+    # no <style> block should exist
+    assert_nil premailer.processed_doc.at('head style')
+  end  
+
   def test_unmergable_media_queries
     html = <<END_HTML
     <html> <head>


### PR DESCRIPTION
Added a config option to allow dropping unused CSS styles from the document. The default behavior is to include any unmerged (non-inlined) styles in a style block at the top of the body. However this can result in a huge block of unneeded css that can make your emails very long (causing them to get clipped in the client). This option lets you turn off that behavior.

I added a test that's passing for my change, but there were a lot of tests failing already which I didn't have time to look at. 