### PR TITLE
Fix plaintext bug for links with single quote marks in the URI (#375)

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -30,8 +30,19 @@ module HtmlToPlainText
     # <img alt=''>
     txt.gsub!(/<img.+?alt=\'([^\']*)\'[^>]*\>/i, '\1')
 
-    # links
-    txt.gsub!(/<a\s[^\n]*?href=["'](mailto:)?([^"']*)["'][^>]*>(.*?)<\/a>/im) do |s|
+    # links with double quotes
+    txt.gsub!(/<a\s[^\n]*?href=["'](mailto:)?([^"]*)["][^>]*>(.*?)<\/a>/im) do |s|
+      if $3.empty?
+        ''
+      elsif $3.strip.downcase == $2.strip.downcase
+        $3.strip
+      else
+        $3.strip + ' ( ' + $2.strip + ' )'
+      end
+    end
+
+    # links with single quotes
+    txt.gsub!(/<a\s[^\n]*?href=["'](mailto:)?([^']*)['][^>]*>(.*?)<\/a>/im) do |s|
       if $3.empty?
         ''
       elsif $3.strip.downcase == $2.strip.downcase

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -173,6 +173,12 @@ END_HTML
 
     # same text and link
     assert_plaintext 'http://example.com', '<a href="http://example.com">http://example.com</a>'
+
+    # link that includes a single quote
+    assert_plaintext "King's Gambit ( https://en.wikipedia.org/wiki/King's_Gambit )", "<a href=\"https://en.wikipedia.org/wiki/King's_Gambit\">King's Gambit</a>"
+
+    # link that includes double quotes
+    assert_plaintext '"Weird Al" Yankovic ( https://en.wikipedia.org/wiki/%22Weird_Al%22_Yankovic )', '<a href="https://en.wikipedia.org/wiki/%22Weird_Al%22_Yankovic">"Weird Al" Yankovic</a>', nil, 100
   end
 
   # see https://github.com/alexdunae/premailer/issues/72


### PR DESCRIPTION
The link regex was matching on either single or double quotes to detect the start/end of an href, so an href that includes a single quote mark as part if the link were not being captured correctly.

This tweaks the link substitution to treat links with single quotes independently from those with double quotes, so that the URIs such as https://en.wikipedia.org/wiki/King's_Gambit are handled correctly.

Fixes  #375