### PR TITLE
Ensure img alt text handled properly

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -5,8 +5,8 @@ require 'htmlentities'
 module HtmlToPlainText
 
   # Returns the text in UTF-8 format with all HTML tags removed
-  #   
-  # HTML content can be omitted from the output by surrounding it in the following comments:   
+  #
+  # HTML content can be omitted from the output by surrounding it in the following comments:
   #
   # <!-- start text/html -->
   # <!-- end text/html -->
@@ -26,14 +26,14 @@ module HtmlToPlainText
     # eg. the following formats:
     # <img alt="" />
     # <img alt="">
-    txt.gsub!(/<img.+?alt=\"([^\"]*)\"[^>]*\>/i, '\1')
+    txt.gsub!(/<img[^>]+?alt=\"([^\"]*)\"[^>]*\>/i, '\1')
 
     # for img tags with '' for attribute quotes
     # with or without closing tag
     # eg. the following formats:
     # <img alt='' />
     # <img alt=''>
-    txt.gsub!(/<img.+?alt=\'([^\']*)\'[^>]*\>/i, '\1')
+    txt.gsub!(/<img[^>]+?alt=\'([^\']*)\'[^>]*\>/i, '\1')
 
     # remove script tags and content
     txt.gsub!(/<script.*\/script>/m, '')

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -130,7 +130,7 @@ END_HTML
   end
 
   def test_img_alt_tags
-    # ensure html imag tags that aren't self-closed are parsed,
+    # ensure html img tags that aren't self-closed are parsed,
     # along with accepting both '' and "" as attribute quotes
 
     # <img alt="" />
@@ -141,6 +141,14 @@ END_HTML
     assert_plaintext 'Example ( http://example.com/ )', "<a href='http://example.com/'><img src='http://example.ru/hello.jpg' alt='Example'/></a>"
     # <img alt=''>
     assert_plaintext 'Example ( http://example.com/ )', "<a href='http://example.com/'><img src='http://example.ru/hello.jpg' alt='Example'></a>"
+
+    # ensure that img alt text is handled properly for multiple
+    # img tags on the same line
+
+    # <img alt="before"> then <img alt="after">
+    assert_plaintext "before then after", '<img alt="before"> then <img alt="after">'
+    # <img> just <img alt="after">
+    assert_plaintext "just after", '<img> just <img alt="after">'
   end
 
   def test_links


### PR DESCRIPTION
This PR is a duplicate of #363, but seeing as that one is over a year old, I decided to clean it up a bit and resubmit.

The basic problem here is that with multiple `img` tags on the same line, if the first one doesn't have an `alt` attribute, but a later one does, the regular expression will greedily match everything in between and throw it away.

## Example

Under normal circumstances, the regular expression will convert each `img` tag to whatever it's alt text value is.

```ruby
Premailer.new('<img alt="before"> then <img alt="after">').to_plain_text
=> "before then after"
```

But here where the first one doesn't have any alt text, the entire string matches the regex for a single img tag and the word `'just'` is removed entirely from the output.

```ruby
Premailer.new('<img> just <img alt="after">').to_plain_text
=> "after"
```

The regex change here is the exact same as the one proposed in #363, but maybe having this based on the latest master will help get it merged in.