### PR TITLE
Fix URI.open deprecation warnings

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -204,7 +204,7 @@ class Premailer
           @base_dir = File.dirname(input)
           thing = File.open(input, 'r')
         else
-          thing = open(input)
+          thing = URI.open(input)
         end
 
         if thing.respond_to?(:read)

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -206,7 +206,7 @@ class Premailer
           @base_dir = File.dirname(input)
           thing = File.open(input, 'r')
         else
-          thing = open(input)
+          thing = URI.open(input)
         end
 
         if thing.respond_to?(:read)

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -204,7 +204,7 @@ class Premailer
           @base_dir = File.dirname(input)
           thing = File.open(input, 'r')
         else
-          thing = open(input)
+          thing = URI.open(input)
         end
 
         if thing.respond_to?(:read)


### PR DESCRIPTION
Prior to this commit the test suite was outputting warnings about
calling Kernel#open. With this commit the test suite is back to a clear
output with nothing but green dots.

```
premailer/adapter/nokogiri_fast.rb:209: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
premailer/adapter/nokogumbo.rb:207: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
premailer/adapter/nokogiri.rb:207: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```