### PR TITLE
Replace deprecated File.exists? with File.exist?

### DIFF
--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -309,7 +309,7 @@ protected
               link_uri = File.join(File.dirname(@html_file), tag.attributes['href'].to_s.sub!(@base_url.to_s, ''))
             end
             # if the file does not exist locally, try to grab the remote reference
-            unless File.exists?(link_uri)
+            unless File.exist?(link_uri)
               link_uri = Premailer.resolve_link(tag.attributes['href'].to_s, @html_file)
             end
           else

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,7 +10,7 @@ class Premailer::TestCase < Minitest::Test
   def setup
     stub_request(:any, /premailer\.dev\/*/).to_return do |request|
       file_path = BASE_PATH + Addressable::URI.parse(request.uri).path
-      if File.exists?(file_path)
+      if File.exist?(file_path)
         { :status => 200, :body => File.open(file_path) }
       else
         { :status => 404, :body => "#{file_path} not found" }


### PR DESCRIPTION
`File.exists?` is deprecated in Ruby 2.8

```
irb(main):001:0> RUBY_VERSION
=> "2.7.1"
irb(main):002:0> File.exists?("")
=> false
irb(main):003:0> File.exist?("")
=> false
```

```
irb(main):001:0> RUBY_VERSION
=> "2.8.0"
irb(main):002:0> File.exists?("")
(irb):2: warning: File.exists? is deprecated; use File.exist? instead
=> false
irb(main):003:0> File.exist?("")
=> false
```