### PR TITLE
Remove "px" from HTML width/height attribute

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -77,13 +77,14 @@ class Premailer
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name) && @options[:css_to_attributes]
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               if el[html_att].nil? and not merged[css_att].empty?
-                new_html_att = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
-                new_html_att = new_html_att.gsub(/(\d+)px/, '\1') if %w[width height].include?(css_att)
-                el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att) : new_html_att
+                new_val = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
+                new_val = new_val.gsub(/(\d+)px/, '\1') if %w[width height].include?(css_att)
+                new_val = ensure_hex(new_val) if css_att.end_with?('color') && @options[:rgb_to_hex_attributes]
+                el[html_att] = new_val
               end
               unless @options[:preserve_style_attribute]
                 merged.instance_variable_get("@declarations").tap do |declarations|
-                    declarations.delete(css_att)
+                  declarations.delete(css_att)
                 end
               end
             end

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -78,6 +78,7 @@ class Premailer
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               if el[html_att].nil? and not merged[css_att].empty?
                 new_html_att = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
+                new_html_att = new_html_att.gsub(/(\d+)px/, '\1') if css_att.in?(%w[width height])
                 el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att) : new_html_att
               end
               unless @options[:preserve_style_attribute]

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -78,7 +78,7 @@ class Premailer
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               if el[html_att].nil? and not merged[css_att].empty?
                 new_html_att = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
-                new_html_att = new_html_att.gsub(/(\d+)px/, '\1') if css_att.in?(%w[width height])
+                new_html_att = new_html_att.gsub(/(\d+)px/, '\1') if %w[width height].include?(css_att)
                 el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att) : new_html_att
               end
               unless @options[:preserve_style_attribute]

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -55,9 +55,7 @@ class Premailer
         end
 
         # Remove script tags
-        if @options[:remove_scripts]
-          doc.search("script").remove
-        end
+        doc.search("script").remove if @options[:remove_scripts]
 
         # Read STYLE attributes and perform folding
         doc.search("*[@style]").each do |el|
@@ -75,20 +73,33 @@ class Premailer
 
           # Duplicate CSS attributes as HTML attributes
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name) && @options[:css_to_attributes]
-            Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
-              if el[html_att].nil? and not merged[css_att].empty?
-                new_val = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
-                new_val = new_val.gsub(/(\d+)px/, '\1') if %w[width height].include?(css_att)
-                new_val = ensure_hex(new_val) if css_att.end_with?('color') && @options[:rgb_to_hex_attributes]
-                el[html_att] = new_val
+            Premailer::RELATED_ATTRIBUTES[el.name].each do |css_attr, html_attr|
+              if el[html_attr].nil? and not merged[css_attr].empty?
+                new_val = merged[css_attr].dup
+
+                # Remove url() function wrapper
+                new_val.gsub!(/url\(['"](.*)['"]\)/, '\1')
+
+                # Remove !important, trailing semi-colon, and leading/trailing whitespace
+                new_val.gsub!(/;$|\s*!important/, '').strip!
+
+                # For width and height tags, remove px units
+                new_val.gsub!(/(\d+)px/, '\1') if %w[width height].include?(css_attr)
+
+                # For color-related tags, convert RGB to hex if specified by options
+                new_val = ensure_hex(new_val) if css_attr.end_with?('color') && @options[:rgb_to_hex_attributes]
+
+                el[html_attr] = new_val
               end
+
               unless @options[:preserve_style_attribute]
                 merged.instance_variable_get("@declarations").tap do |declarations|
-                  declarations.delete(css_att)
+                  declarations.delete(css_attr)
                 end
               end
             end
           end
+
           # Collapse multiple rules into one as much as possible.
           merged.create_shorthand! if @options[:create_shorthands]
 

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -80,7 +80,7 @@ class Premailer
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               if el[html_att].nil? and not merged[css_att].empty?
                 new_html_att = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
-                new_html_att = new_html_att.gsub(/(\d+)px/, '\1') if css_att.in?(%w[width height])
+                new_html_att = new_html_att.gsub(/(\d+)px/, '\1') if %w[width height].include?(css_att)
                 el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att) : new_html_att
               end
               unless @options[:preserve_style_attribute]

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -80,6 +80,7 @@ class Premailer
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               if el[html_att].nil? and not merged[css_att].empty?
                 new_html_att = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
+                new_html_att = new_html_att.gsub(/(\d+)px/, '\1') if css_att.in?(%w[width height])
                 el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att) : new_html_att
               end
               unless @options[:preserve_style_attribute]

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -79,13 +79,14 @@ class Premailer
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name) && @options[:css_to_attributes]
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               if el[html_att].nil? and not merged[css_att].empty?
-                new_html_att = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
-                new_html_att = new_html_att.gsub(/(\d+)px/, '\1') if %w[width height].include?(css_att)
-                el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att) : new_html_att
+                new_val = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
+                new_val = new_val.gsub(/(\d+)px/, '\1') if %w[width height].include?(css_att)
+                new_val = ensure_hex(new_val) if css_att.end_with?('color') && @options[:rgb_to_hex_attributes]
+                el[html_att] = new_val
               end
               unless @options[:preserve_style_attribute]
                 merged.instance_variable_get("@declarations").tap do |declarations|
-                    declarations.delete(css_att)
+                  declarations.delete(css_att)
                 end
               end
             end

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -77,13 +77,14 @@ class Premailer
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name) && @options[:css_to_attributes]
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               if el[html_att].nil? and not merged[css_att].empty?
-                new_html_att = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
-                new_html_att = new_html_att.gsub(/(\d+)px/, '\1') if %w[width height].include?(css_att)
-                el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att) : new_html_att
+                new_val = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
+                new_val = new_val.gsub(/(\d+)px/, '\1') if %w[width height].include?(css_att)
+                new_val = ensure_hex(new_val) if css_att.end_with?('color') && @options[:rgb_to_hex_attributes]
+                el[html_att] = new_val
               end
               unless @options[:preserve_style_attribute]
                 merged.instance_variable_get("@declarations").tap do |declarations|
-                    declarations.delete(css_att)
+                  declarations.delete(css_att)
                 end
               end
             end

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -78,6 +78,7 @@ class Premailer
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               if el[html_att].nil? and not merged[css_att].empty?
                 new_html_att = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
+                new_html_att = new_html_att.gsub(/(\d+)px/, '\1') if css_att.in?(%w[width height])
                 el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att) : new_html_att
               end
               unless @options[:preserve_style_attribute]

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -78,7 +78,7 @@ class Premailer
             Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
               if el[html_att].nil? and not merged[css_att].empty?
                 new_html_att = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
-                new_html_att = new_html_att.gsub(/(\d+)px/, '\1') if css_att.in?(%w[width height])
+                new_html_att = new_html_att.gsub(/(\d+)px/, '\1') if %w[width height].include?(css_att)
                 el[html_att] = css_att.end_with?('color') && @options[:rgb_to_hex_attributes] ? ensure_hex(new_html_att) : new_html_att
               end
               unless @options[:preserve_style_attribute]

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -55,9 +55,7 @@ class Premailer
         end
 
         # Remove script tags
-        if @options[:remove_scripts]
-          doc.search("script").remove
-        end
+        doc.search("script").remove if @options[:remove_scripts]
 
         # Read STYLE attributes and perform folding
         doc.search("*[@style]").each do |el|
@@ -75,20 +73,33 @@ class Premailer
 
           # Duplicate CSS attributes as HTML attributes
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name) && @options[:css_to_attributes]
-            Premailer::RELATED_ATTRIBUTES[el.name].each do |css_att, html_att|
-              if el[html_att].nil? and not merged[css_att].empty?
-                new_val = merged[css_att].gsub(/url\(['"](.*)['"]\)/, '\1').gsub(/;$|\s*!important/, '').strip
-                new_val = new_val.gsub(/(\d+)px/, '\1') if %w[width height].include?(css_att)
-                new_val = ensure_hex(new_val) if css_att.end_with?('color') && @options[:rgb_to_hex_attributes]
-                el[html_att] = new_val
+            Premailer::RELATED_ATTRIBUTES[el.name].each do |css_attr, html_attr|
+              if el[html_attr].nil? and not merged[css_attr].empty?
+                new_val = merged[css_attr].dup
+
+                # Remove url() function wrapper
+                new_val.gsub!(/url\(['"](.*)['"]\)/, '\1')
+
+                # Remove !important, trailing semi-colon, and leading/trailing whitespace
+                new_val.gsub!(/;$|\s*!important/, '').strip!
+
+                # For width and height tags, remove px units
+                new_val.gsub!(/(\d+)px/, '\1') if %w[width height].include?(css_attr)
+
+                # For color-related tags, convert RGB to hex if specified by options
+                new_val = ensure_hex(new_val) if css_attr.end_with?('color') && @options[:rgb_to_hex_attributes]
+
+                el[html_attr] = new_val
               end
+
               unless @options[:preserve_style_attribute]
                 merged.instance_variable_get("@declarations").tap do |declarations|
-                  declarations.delete(css_att)
+                  declarations.delete(css_attr)
                 end
               end
             end
           end
+
           # Collapse multiple rules into one as much as possible.
           merged.create_shorthand! if @options[:create_shorthands]
 


### PR DESCRIPTION
MS Outlook doesn't honor `<img width="200px">` and instead requires `<img width="200">`. The Mozilla docs also state "Must be an integer without a unit."
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-width

This change converts `-premailer-width: 100px` to `width=100` in the HTML attribute (same for `height`). It is useful when working with SASS variables for example so that you can do:

```
$my-width: 100px;
width: $my-width;
-premailer-width: $my-width;
```

I've made this change specific to the width/height attrs only. I can't think of any case where you wouldn't want to apply this transformation.