### PR TITLE
Fix to converting inline html 100px to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Premailer CHANGELOG
 
+### Verion 1.14.1
+* Fix to converting inline html 100px to 100
+
 ### Verion 1.14.0
 * Convert inline html 100px to 100
 

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -84,7 +84,7 @@ class Premailer
                 new_val.gsub!(/;$|\s*!important/, '').strip!
 
                 # For width and height tags, remove px units
-                new_val.gsub!(/(\d+)px/, '\1') if %w[width height].include?(css_attr)
+                new_val.gsub!(/(\d+)px/, '\1') if %w[width height].include?(html_attr)
 
                 # For color-related tags, convert RGB to hex if specified by options
                 new_val = ensure_hex(new_val) if css_attr.end_with?('color') && @options[:rgb_to_hex_attributes]

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -88,7 +88,7 @@ class Premailer
                 new_val.gsub!(/;$|\s*!important/, '').strip!
 
                 # For width and height tags, remove px units
-                new_val.gsub!(/(\d+)px/, '\1') if %w[width height].include?(css_attr)
+                new_val.gsub!(/(\d+)px/, '\1') if %w[width height].include?(html_attr)
 
                 # For color-related tags, convert RGB to hex if specified by options
                 new_val = ensure_hex(new_val) if css_attr.end_with?('color') && @options[:rgb_to_hex_attributes]

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -84,7 +84,7 @@ class Premailer
                 new_val.gsub!(/;$|\s*!important/, '').strip!
 
                 # For width and height tags, remove px units
-                new_val.gsub!(/(\d+)px/, '\1') if %w[width height].include?(css_attr)
+                new_val.gsub!(/(\d+)px/, '\1') if %w[width height].include?(html_attr)
 
                 # For color-related tags, convert RGB to hex if specified by options
                 new_val = ensure_hex(new_val) if css_attr.end_with?('color') && @options[:rgb_to_hex_attributes]

--- a/lib/premailer/version.rb
+++ b/lib/premailer/version.rb
@@ -1,4 +1,4 @@
 class Premailer
   # Premailer version.
-  VERSION = '1.14.0'.freeze
+  VERSION = '1.14.1'.freeze
 end


### PR DESCRIPTION
This is a fix to the recently merged PR. My apologies for the oversight. I've tested this and it's now working as intended.

Version/changelog also added.