### PR TITLE
Make 'url()' wrapper stripping more robust

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -78,7 +78,7 @@ class Premailer
                 new_val = merged[css_attr].dup
 
                 # Remove url() function wrapper
-                new_val.gsub!(/url\(['"](.*)['"]\)/, '\1')
+                new_val.gsub!(/url\((['"])(.*?)\1\)/, '\2')
 
                 # Remove !important, trailing semi-colon, and leading/trailing whitespace
                 new_val.gsub!(/;$|\s*!important/, '').strip!

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -82,7 +82,7 @@ class Premailer
                 new_val = merged[css_attr].dup
 
                 # Remove url() function wrapper
-                new_val.gsub!(/url\(['"](.*)['"]\)/, '\1')
+                new_val.gsub!(/url\((['"])(.*?)\1\)/, '\2')
 
                 # Remove !important, trailing semi-colon, and leading/trailing whitespace
                 new_val.gsub!(/;$|\s*!important/, '').strip!

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -78,7 +78,7 @@ class Premailer
                 new_val = merged[css_attr].dup
 
                 # Remove url() function wrapper
-                new_val.gsub!(/url\(['"](.*)['"]\)/, '\1')
+                new_val.gsub!(/url\((['"])(.*?)\1\)/, '\2')
 
                 # Remove !important, trailing semi-colon, and leading/trailing whitespace
                 new_val.gsub!(/;$|\s*!important/, '').strip!


### PR DESCRIPTION
Now requires beginning and ending quote style to match, and matches lazily so two url()s on the same line are treated independently.