### PR TITLE
Minor: Remove relative cleaner loop in canonicalize

### DIFF
--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -178,7 +178,7 @@ class Premailer
   # @option options [String] :output_encoding Output encoding option for Nokogiri adapter. Should be set to "US-ASCII" to output HTML entities instead of Unicode characters.
   # @option options [Boolean] :create_shorthands Combine several properties into a shorthand one, e.g. font: style weight size. Default is true.
   # @option options [Boolean] :html_fragment Handle HTML fragment without any HTML content wrappers. Default is false.
-  # @option options [Boolean] :drop_unmergeable_css_rules Do not include unmergeable css rules in a <tt><style><tt> tag. Default is false.  
+  # @option options [Boolean] :drop_unmergeable_css_rules Do not include unmergeable css rules in a <tt><style><tt> tag. Default is false.
   def initialize(html, options = {})
     @options = {:warn_level => Warnings::SAFE,
                 :line_length => 65,
@@ -499,14 +499,8 @@ public
   def self.canonicalize(uri) # :nodoc:
     u = uri.kind_of?(Addressable::URI) ? uri : Addressable::URI.parse(uri.to_s)
     u.normalize!
-    newpath = u.path
-    while newpath.gsub!(%r{([^/]+)/\.\./?}) { |match|
-        $1 == '..' ? match : ''
-      } do end
-      newpath = newpath.gsub(%r{/\./}, '/').sub(%r{/\.\z}, '/')
-      u.path = newpath
-      u.to_s
-    end
+    u.to_s
+  end
 
   # Check <tt>CLIENT_SUPPORT_FILE</tt> for any CSS warnings
   def check_client_support # :nodoc:


### PR DESCRIPTION
TLDR: Since Addressable::URI is now used instead of URI, uri are now normalized better than before, this loop is unneeded

Hello,

We discovered this with an issue with an earlier version, where this loop would go infinite in links like https://github.com/../../file.css

Because "../../" would match the regex, be replaced by itself and go on again and again.

e.g.
```ruby
require 'addressable'
uri = "https://github.com/one/../../file.html"
URI.parse(uri).normalize.to_s
# => "https://github.com/one/../../file.html"
Addressable::URI.parse(uri).normalize.to_s
# => "https://github.com/file.html"
```

Currently the while block is doing nothing because Addressable URI already does the job so might as well remove it.
