### PR TITLE
Find `a` tags first and then parse them for `href`s

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -1,9 +1,7 @@
-# coding: utf-8
 require 'htmlentities'
 
 # Support functions for Premailer
 module HtmlToPlainText
-
   # Returns the text in UTF-8 format with all HTML tags removed
   #
   # HTML content can be omitted from the output by surrounding it in the following comments:
@@ -13,13 +11,13 @@ module HtmlToPlainText
   #
   # TODO: add support for DL, OL
   # TODO: this is not safe and needs a real html parser to work
-  def convert_to_text(html, line_length = 65, from_charset = 'UTF-8')
+  def convert_to_text(html, line_length = 65, _from_charset = 'UTF-8')
     txt = html
 
     # strip text ignored html. Useful for removing
     # headers and footers that aren't needed in the
     # text version
-    txt.gsub!(/<!-- start text\/html -->.*?<!-- end text\/html -->/m, '')
+    txt.gsub!(%r{<!-- start text/html -->.*?<!-- end text/html -->}m, '')
 
     # replace images with their alt attributes
     # for img tags with "" for attribute quotes
@@ -37,70 +35,67 @@ module HtmlToPlainText
     txt.gsub!(/<img[^>]+?alt='([^']*)'[^>]*>/i, '\1')
 
     # remove script tags and content
-    txt.gsub!(/<script.*?\/script>/m, '')
+    txt.gsub!(%r{<script.*?/script>}m, '')
 
-    # links with double quotes
-    txt.gsub!(/<a\s[^\n]*?href=["'](mailto:)?([^"]*)["][^>]*>(.*?)<\/a>/im) do |s|
-      if $3.empty?
-        ''
-      elsif $3.strip.downcase == $2.strip.downcase
-        $3.strip
-      else
-        $3.strip + ' ( ' + $2.strip + ' )'
+    # links
+    txt.gsub!(%r{<a[\s]+([^>]+)>((?:.(?!\</a\>))*.)</a>}im) do |s|
+      text = Regexp.last_match(2).strip
+      href = nil
+
+      ["'", '"'].each do |quote_char|
+        match = /href=#{quote_char}(mailto:)?([^#{quote_char}]*)#{quote_char}/.match(s)
+        href = match[2] unless match.nil?
       end
-    end
 
-    # links with single quotes
-    txt.gsub!(/<a\s[^\n]*?href=["'](mailto:)?([^']*)['][^>]*>(.*?)<\/a>/im) do |s|
-      if $3.empty?
+      if text.empty?
         ''
-      elsif $3.strip.downcase == $2.strip.downcase
-        $3.strip
+      elsif href.nil? || text.strip.downcase == href.strip.downcase
+        text.strip
       else
-        $3.strip + ' ( ' + $2.strip + ' )'
+        text.strip + ' ( ' + href.strip + ' )'
       end
     end
 
     # handle headings (H1-H6)
-    txt.gsub!(/(<\/h[1-6]>)/i, "\n\\1") # move closing tags to new lines
-    txt.gsub!(/[\s]*<h([1-6]+)[^>]*>[\s]*(.*)[\s]*<\/h[1-6]+>/i) do |s|
-      hlevel = $1.to_i
+    txt.gsub!(%r{(</h[1-6]>)}i, "\n\\1") # move closing tags to new lines
+    txt.gsub!(%r{[\s]*<h([1-6]+)[^>]*>[\s]*(.*)[\s]*</h[1-6]+>}i) do |_s|
+      hlevel = Regexp.last_match(1).to_i
 
-      htext = $2
-      htext.gsub!(/<br[\s]*\/?>/i, "\n") # handle <br>s
-      htext.gsub!(/<\/?[^>]*>/i, '') # strip tags
+      htext = Regexp.last_match(2)
+      htext.gsub!(%r{<br[\s]*/?>}i, "\n") # handle <br>s
+      htext.gsub!(%r{</?[^>]*>}i, '') # strip tags
 
       # determine maximum line length
       hlength = 0
       htext.each_line { |l| llength = l.strip.length; hlength = llength if llength > hlength }
       hlength = line_length if hlength > line_length
 
-      case hlevel
-      when 1   # H1, asterisks above and below
-        htext = ('*' * hlength) + "\n" + htext + "\n" + ('*' * hlength)
-      when 2   # H1, dashes above and below
-        htext = ('-' * hlength) + "\n" + htext + "\n" + ('-' * hlength)
-      else     # H3-H6, dashes below
-        htext = htext + "\n" + ('-' * hlength)
-      end
+      htext = case hlevel
+              when 1   # H1, asterisks above and below
+                ('*' * hlength) + "\n" + htext + "\n" + ('*' * hlength)
+              when 2   # H1, dashes above and below
+                ('-' * hlength) + "\n" + htext + "\n" + ('-' * hlength)
+              else # H3-H6, dashes below
+                htext + "\n" + ('-' * hlength)
+              end
 
       "\n\n" + htext + "\n\n"
     end
 
     # wrap spans
-    txt.gsub!(/(<\/span>)[\s]+(<span)/mi, '\1 \2')
+    txt.gsub!(%r{(</span>)[\s]+(<span)}mi, '\1 \2')
 
     # lists -- TODO: should handle ordered lists
     txt.gsub!(/[\s]*(<li[^>]*>)[\s]*/i, '* ')
     # list not followed by a newline
-    txt.gsub!(/<\/li>[\s]*(?![\n])/i, "\n")
+    txt.gsub!(%r{</li>[\s]*(?![\n])}i, "\n")
 
     # paragraphs and line breaks
-    txt.gsub!(/<\/p>/i, "\n\n")
-    txt.gsub!(/<br[\/ ]*>/i, "\n")
+    txt.gsub!(%r{</p>}i, "\n\n")
+    txt.gsub!(%r{<br[/ ]*>}i, "\n")
 
     # strip remaining tags
-    txt.gsub!(/<\/?[^>]*>/, '')
+    txt.gsub!(%r{</?[^>]*>}, '')
 
     # decode HTML entities
     he = HTMLEntities.new
@@ -113,7 +108,7 @@ module HtmlToPlainText
     txt.gsub!(/\r\n?/, "\n")
 
     # strip extra spaces
-    txt.gsub!(/[ \t]*\302\240+[ \t]*/, " ") # non-breaking spaces -> spaces
+    txt.gsub!(/[ \t]*\302\240+[ \t]*/, ' ') # non-breaking spaces -> spaces
     txt.gsub!(/\n[ \t]+/, "\n") # space at start of lines
     txt.gsub!(/[ \t]+\n/, "\n") # space at end of lines
 
@@ -121,8 +116,8 @@ module HtmlToPlainText
     txt.gsub!(/[\n]{3,}/, "\n\n")
 
     # the word messes up the parens
-    txt.gsub!(/\(([ \n])(http[^)]+)([\n ])\)/) do |s|
-      ($1 == "\n" ? $1 : '' ) + '( ' + $2 + ' )' + ($3 == "\n" ? $1 : '' )
+    txt.gsub!(/\(([ \n])(http[^)]+)([\n ])\)/) do |_s|
+      (Regexp.last_match(1) == "\n" ? Regexp.last_match(1) : '') + '( ' + Regexp.last_match(2) + ' )' + (Regexp.last_match(3) == "\n" ? Regexp.last_match(1) : '')
     end
 
     txt.strip

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -222,6 +222,15 @@ END_HTML
     HTML
   end
 
+  def test_link_with_no_href
+    assert_plaintext 'foobar ( http://example.com/ )', '<a>foo</a><a href="http://example.com/">bar</a>'
+    assert_plaintext 'foobar ( http://example.com/ )', "<a>foo</a><a href='http://example.com/'>bar</a>"
+    assert_plaintext 'foobar ( http://example.com/ )', '<a attr="attr">foo</a><a href="http://example.com/">bar</a>'
+    assert_plaintext 'foobar ( http://example.com/ )', '<a attr=\'attr\'>foo</a><a href="http://example.com/">bar</a>'
+    assert_plaintext 'foobar ( http://example.com/ )', "<a attr='attr'>foo</a><a href='http://example.com/'>bar</a>"
+    assert_plaintext 'foobar ( http://example.com/ )', "<a attr=\"attr\">foo</a><a href='http://example.com/'>bar</a>"
+  end
+
   def assert_plaintext(out, raw, msg = nil, line_length = 65)
     assert_equal out, convert_to_text(raw, line_length), msg
   end


### PR DESCRIPTION
Addresses https://github.com/premailer/premailer/issues/404

Simply making the `href` portion of the regex optional didn't work for blobbing reasons.