### PR TITLE
Find `a` tags first and then parse them for `href`s

### DIFF
--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -40,7 +40,7 @@ module HtmlToPlainText
     txt.gsub!(/<script.*?\/script>/m, '')
 
     # links
-    txt.gsub!(/<a[\s]+([^>]+)>((?:.(?!\<\/a\>))*.)<\/a>/im) do |s|
+    txt.gsub!(/<a\s+([^>]+)>(.*?)<\/a>/im) do |s|
       text = $2.strip
       href = nil
 

--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -42,13 +42,10 @@ module HtmlToPlainText
     # links
     txt.gsub!(/<a\s+([^>]+)>(.*?)<\/a>/im) do |s|
       text = $2.strip
-      href = nil
 
-      ["'", '"'].each() do |quote_char|
-        match = /href=#{quote_char}(mailto:)?([^#{quote_char}]*)#{quote_char}/.match(s)
-        if !match.nil?
-          href = match[2]
-        end
+      match = /href=(['"])(?:mailto:)?(.+?)\1/.match(s)
+      if match
+        href = match[2]
       end
 
       if text.empty?

--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -39,25 +39,24 @@ module HtmlToPlainText
     # remove script tags and content
     txt.gsub!(/<script.*?\/script>/m, '')
 
-    # links with double quotes
-    txt.gsub!(/<a\s[^\n]*?href=["'](mailto:)?([^"]*)["][^>]*>(.*?)<\/a>/im) do |s|
-      if $3.empty?
-        ''
-      elsif $3.strip.downcase == $2.strip.downcase
-        $3.strip
-      else
-        $3.strip + ' ( ' + $2.strip + ' )'
-      end
-    end
+    # links
+    txt.gsub!(/<a[\s]+([^>]+)>((?:.(?!\<\/a\>))*.)<\/a>/im) do |s|
+      text = $2.strip
+      href = nil
 
-    # links with single quotes
-    txt.gsub!(/<a\s[^\n]*?href=["'](mailto:)?([^']*)['][^>]*>(.*?)<\/a>/im) do |s|
-      if $3.empty?
+      ["'", '"'].each() do |quote_char|
+        match = /href=#{quote_char}(mailto:)?([^#{quote_char}]*)#{quote_char}/.match(s)
+        if !match.nil?
+          href = match[2]
+        end
+      end
+
+      if text.empty?
         ''
-      elsif $3.strip.downcase == $2.strip.downcase
-        $3.strip
+      elsif href.nil? || text.strip.downcase == href.strip.downcase
+        text.strip
       else
-        $3.strip + ' ( ' + $2.strip + ' )'
+        text.strip + ' ( ' + href.strip + ' )'
       end
     end
 

--- a/test/test_html_to_plain_text.rb
+++ b/test/test_html_to_plain_text.rb
@@ -222,6 +222,15 @@ END_HTML
     HTML
   end
 
+  def test_link_with_no_href
+    assert_plaintext 'foobar ( http://example.com/ )', '<a>foo</a><a href="http://example.com/">bar</a>'
+    assert_plaintext 'foobar ( http://example.com/ )', "<a>foo</a><a href='http://example.com/'>bar</a>"
+    assert_plaintext 'foobar ( http://example.com/ )', '<a attr="attr">foo</a><a href="http://example.com/">bar</a>'
+    assert_plaintext 'foobar ( http://example.com/ )', '<a attr=\'attr\'>foo</a><a href="http://example.com/">bar</a>'
+    assert_plaintext 'foobar ( http://example.com/ )', "<a attr='attr'>foo</a><a href='http://example.com/'>bar</a>"
+    assert_plaintext 'foobar ( http://example.com/ )', "<a attr=\"attr\">foo</a><a href='http://example.com/'>bar</a>"
+  end
+
   def assert_plaintext(out, raw, msg = nil, line_length = 65)
     assert_equal out, convert_to_text(raw, line_length), msg
   end


### PR DESCRIPTION
This addresses https://github.com/premailer/premailer/issues/404.

Simply making the `href` portion of the original regex optional didn't work for globbing reasons.