### PR TITLE
Switch MD5 hash to SHA-256

### DIFF
--- a/lib/premailer.rb
+++ b/lib/premailer.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 require 'open-uri'
-require 'digest/md5'
+require 'digest/sha2'
 require 'cgi'
 require 'addressable/uri'
 require 'css_parser'

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -125,13 +125,13 @@ class Premailer
           doc.search("a[@href^='#']").each do |el|
             target = el.get_attribute('href')[1..-1]
             targets << target
-            el.set_attribute('href', "#" + Digest::MD5.hexdigest(target))
+            el.set_attribute('href', "#" + Digest::SHA256.hexdigest(target))
           end
           # hash ids that are links target, delete others
           doc.search("*[@id]").each do |el|
             id = el.get_attribute('id')
             if targets.include?(id)
-              el.set_attribute('id', Digest::MD5.hexdigest(id))
+              el.set_attribute('id', Digest::SHA256.hexdigest(id))
             else
               el.remove_attribute('id')
             end

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -129,13 +129,13 @@ class Premailer
           doc.search("a[@href^='#']").each do |el|
             target = el.get_attribute('href')[1..-1]
             targets << target
-            el.set_attribute('href', "#" + Digest::MD5.hexdigest(target))
+            el.set_attribute('href', "#" + Digest::SHA256.hexdigest(target))
           end
           # hash ids that are links target, delete others
           doc.search("*[@id]").each do |el|
             id = el.get_attribute('id')
             if targets.include?(id)
-              el.set_attribute('id', Digest::MD5.hexdigest(id))
+              el.set_attribute('id', Digest::SHA256.hexdigest(id))
             else
               el.remove_attribute('id')
             end

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -123,13 +123,13 @@ class Premailer
           doc.search("a[@href^='#']").each do |el|
             target = el.get_attribute('href')[1..-1]
             targets << target
-            el.set_attribute('href', "#" + Digest::MD5.hexdigest(target))
+            el.set_attribute('href', "#" + Digest::SHA256.hexdigest(target))
           end
           # hash ids that are links target, delete others
           doc.search("*[@id]").each do |el|
             id = el.get_attribute('id')
             if targets.include?(id)
-              el.set_attribute('id', Digest::MD5.hexdigest(id))
+              el.set_attribute('id', Digest::SHA256.hexdigest(id))
             else
               el.remove_attribute('id')
             end


### PR DESCRIPTION
FIPS-compliant systems can no longer use MD5 as it is
cryptographically broken. This commit switches the hash algorithm to
SHA256.