### PR TITLE
Update nokogiri to v1.13.4

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         task: ["test"]
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.7', '3.0' ]
     name: ${{ matrix.ruby }} rake ${{ matrix.task }}
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,13 +33,13 @@ GEM
     maxitest (4.1.0)
       minitest (>= 5.0.0, < 5.15.0)
     method_source (1.0.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.8.0)
     minitest (5.14.4)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
-    nokogiri (1.8.5-java)
-    nokogumbo (2.0.5)
-      nokogiri (~> 1.8, >= 1.8.4)
+    nokogiri (1.13.4)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.13.4-java)
+      racc (~> 1.4)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -48,6 +48,8 @@ GEM
       method_source (~> 1.0)
       spoon (~> 0.0)
     public_suffix (4.0.6)
+    racc (1.6.0)
+    racc (1.6.0-java)
     rake (13.0.6)
     redcarpet (3.5.1)
     rexml (3.2.5)
@@ -79,8 +81,7 @@ DEPENDENCIES
   coveralls
   jruby-openssl
   maxitest
-  nokogiri (~> 1.8.2)
-  nokogumbo
+  nokogiri (~> 1.13)
   premailer!
   pry
   rake (> 0.8, != 0.9.0)
@@ -88,4 +89,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.0.rc.2
+   2.3.6

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -1,5 +1,3 @@
-require 'nokogumbo'
-
 class Premailer
   module Adapter
     # Nokogiri adapter

--- a/premailer.gemspec
+++ b/premailer.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new "premailer", Premailer::VERSION do |s|
   s.author  = "Alex Dunae"
   s.files            = `git ls-files lib misc LICENSE.md README.md`.split("\n")
   s.executables      = ['premailer']
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.metadata["yard.run"] = "yri" # use "yard" to build full HTML docs.
 
   s.add_runtime_dependency 'css_parser', '>= 1.6.0'
@@ -17,12 +17,11 @@ Gem::Specification.new "premailer", Premailer::VERSION do |s|
   s.add_runtime_dependency 'addressable'
   s.add_development_dependency "bundler", ">= 1.3"
   s.add_development_dependency 'rake', ['> 0.8',  '!= 0.9.0']
-  s.add_development_dependency 'nokogiri', '~> 1.8.2'
+  s.add_development_dependency 'nokogiri', '~> 1.13'
   s.add_development_dependency 'redcarpet', '~> 3.0'
   s.add_development_dependency 'maxitest'
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'webmock'
-  s.add_development_dependency 'nokogumbo'
   s.add_development_dependency 'bump'
 end
 


### PR DESCRIPTION
This fixes a number of CVEs and drops the need for nokogumbo: https://github.com/sparklemotion/nokogiri/issues/2205

Also drops Ruby 2.5 and 2.6 since they reached EOL (https://www.ruby-lang.org/en/downloads/branches/).