### PR TITLE
Add option to swallow ArgumentErrors (CssParser)

### DIFF
--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -169,6 +169,7 @@ class Premailer
   # @option options [Boolean] :with_html_string Whether the html param should be treated as a raw string. Default is false.
   # @option options [Boolean] :verbose Whether to print errors and warnings to <tt>$stderr</tt>.  Default is false.
   # @option options [Boolean] :io_exceptions Throws exceptions on I/O errors.
+  # @option options [Boolean] :rule_set_exceptions Silently swallow ArgumentErrors generated from RuleSet. (CssParser)
   # @option options [Boolean] :include_link_tags Whether to include css from <tt>link rel=stylesheet</tt> tags.  Default is true.
   # @option options [Boolean] :include_style_tags Whether to include css from <tt>style</tt> tags.  Default is true.
   # @option options [String] :input_encoding Manually specify the source documents encoding. This is a good idea. Default is ASCII-8BIT.
@@ -200,6 +201,7 @@ class Premailer
                 :verbose => false,
                 :debug => false,
                 :io_exceptions => false,
+                :rule_set_exceptions => false,
                 :include_link_tags => true,
                 :include_style_tags => true,
                 :input_encoding => 'ASCII-8BIT',
@@ -233,7 +235,8 @@ class Premailer
     @css_parser = CssParser::Parser.new({
       :absolute_paths => true,
       :import => true,
-      :io_exceptions => @options[:io_exceptions]
+      :io_exceptions => @options[:io_exceptions],
+      :rule_set_exceptions => @options[:rule_set_exceptions]
     })
 
     @adapter_class = Adapter.find @options[:adapter]


### PR DESCRIPTION
CssParser prior to version 1.7.1 swallowed malformed css rules silently. Starting with version 1.8.0 it threw an error for invalid CSS. The newest version of CssParser added a new option `rule_set_exceptions` to silently swallow ArgumentErrors generated from RuleSet.

This PR adds a option `rule_set_exceptions`  to premailer to pass on to CssParser.