### PR TITLE
CI: add Ruby 3.2 to the test matrix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         task: ["test"]
-        ruby: [ '2.7', '3.0', '3.1' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
     name: ${{ matrix.ruby }} rake ${{ matrix.task }}
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     bump (0.10.0)
     coderay (1.1.3)
     coveralls (0.8.23)
@@ -21,35 +21,39 @@ GEM
       tins (~> 1.6)
     crack (0.4.5)
       rexml
-    css_parser (1.12.0)
+    css_parser (1.14.0)
       addressable
     docile (1.4.0)
-    ffi (1.15.4-java)
+    ffi (1.15.5-java)
     hashdiff (1.0.1)
     htmlentities (4.3.4)
-    jruby-openssl (0.11.0-java)
-    json (2.6.1)
-    json (2.6.1-java)
-    maxitest (4.1.0)
-      minitest (>= 5.0.0, < 5.15.0)
+    jruby-openssl (0.14.0-java)
+    json (2.6.3)
+    json (2.6.3-java)
+    maxitest (4.4.0)
+      minitest (>= 5.0.0, < 5.18.0)
     method_source (1.0.0)
-    mini_portile2 (2.8.0)
-    minitest (5.14.4)
-    nokogiri (1.13.4)
+    mini_portile2 (2.8.1)
+    minitest (5.17.0)
+    nokogiri (1.14.0)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.4-java)
+    nokogiri (1.14.0-aarch64-linux)
       racc (~> 1.4)
-    pry (0.14.1)
+    nokogiri (1.14.0-java)
+      racc (~> 1.4)
+    nokogiri (1.14.0-x86_64-linux)
+      racc (~> 1.4)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry (0.14.1-java)
+    pry (0.14.2-java)
       coderay (~> 1.1)
       method_source (~> 1.0)
       spoon (~> 0.0)
-    public_suffix (4.0.6)
-    racc (1.6.0)
-    racc (1.6.0-java)
+    public_suffix (5.0.1)
+    racc (1.6.2)
+    racc (1.6.2-java)
     rake (13.0.6)
     redcarpet (3.5.1)
     rexml (3.2.5)
@@ -63,17 +67,19 @@ GEM
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    thor (1.1.0)
-    tins (1.29.1)
+    thor (1.2.1)
+    tins (1.32.1)
       sync
-    webmock (3.14.0)
+    webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  aarch64-linux
   java
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bump
@@ -89,4 +95,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.12
+   2.4.5


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it to the build matrix.

Also run `bundle update` to get the latest dependencies.