### PR TITLE
Remove conditional behaviour for Ruby 1.9

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -237,14 +237,7 @@ class Premailer
             thing.gsub! entity, replacement
           end
         end
-        # Default encoding is ASCII-8BIT (binary) per http://groups.google.com/group/nokogiri-talk/msg/0b81ef0dc180dc74
-        # However, we really don't want to hardcode this. ASCII-8BIT should be the default, but not the only option.
-        encoding = if thing.is_a?(String) and RUBY_VERSION =~ /1.9/
-          thing = thing.force_encoding(@options[:input_encoding]).encode!
-          @options[:input_encoding]
-        else
-          @options[:input_encoding] || (RUBY_PLATFORM == 'java' ? nil : 'BINARY')
-        end
+        encoding = @options[:input_encoding] || (RUBY_PLATFORM == 'java' ? nil : 'BINARY')
         doc = if @options[:html_fragment]
           ::Nokogiri::HTML.fragment(thing, encoding)
         else

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -237,14 +237,7 @@ class Premailer
             thing.gsub! entity, replacement
           end
         end
-        # Default encoding is ASCII-8BIT (binary) per http://groups.google.com/group/nokogiri-talk/msg/0b81ef0dc180dc74
-        # However, we really don't want to hardcode this. ASCII-8BIT should be the default, but not the only option.
-        encoding = if thing.is_a?(String) and RUBY_VERSION =~ /1.9/
-          thing = thing.force_encoding(@options[:input_encoding]).encode!
-          @options[:input_encoding]
-        else
-          @options[:input_encoding] || (RUBY_PLATFORM == 'java' ? nil : 'BINARY')
-        end
+        encoding = @options[:input_encoding] || (RUBY_PLATFORM == 'java' ? nil : 'BINARY')
         doc = if @options[:html_fragment]
           ::Nokogiri::HTML.fragment(thing, encoding)
         else

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -231,11 +231,6 @@ class Premailer
             thing.gsub! entity, replacement
           end
         end
-        # Default encoding is ASCII-8BIT (binary) per http://groups.google.com/group/nokogiri-talk/msg/0b81ef0dc180dc74
-        # However, we really don't want to hardcode this. ASCII-8BIT should be the default, but not the only option.
-        if thing.is_a?(String) and RUBY_VERSION =~ /1.9/
-          thing = thing.force_encoding(@options[:input_encoding]).encode!
-        end
         doc = if @options[:html_fragment]
           ::Nokogiri::HTML5.fragment(thing)
         else


### PR DESCRIPTION
The minimum supported version of Ruby is now 2.7, so this conditional behaviour is no-longer needed.