### PR TITLE
catch errors during expand_shorthand and handle using rule_set_exceptions

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -73,7 +73,11 @@ class Premailer
 
           # Perform style folding
           merged = CssParser.merge(declarations)
-          merged.expand_shorthand!
+          begin
+            merged.expand_shorthand!
+          rescue ArgumentError => e
+            raise e if @options[:rule_set_exceptions]
+          end
 
           # Duplicate CSS attributes as HTML attributes
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name) && @options[:css_to_attributes]

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -405,7 +405,22 @@ END_HTML
         }
       </style></head><body>
         <div style="color: !important;">Test no color</div>
-        <div style="margin: 0px 0px 0px 0 px;">Test invalid margin</div>
+      </body></html>
+    END_HTML
+
+    assert_raises(ArgumentError) do
+      pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri)
+      pm.to_inline_css
+    end
+
+    pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri, rule_set_exceptions: false)
+    pm.to_inline_css
+  end
+
+  def test_invalid_shorthand_css
+    html = <<-END_HTML
+      <html><head></head><body>
+      <div style="margin: 0px 0px 0px 0 px;">Test invalid margin</div>
       </body></html>
     END_HTML
 

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -404,7 +404,8 @@ END_HTML
           color: !important;
         }
       </style></head><body>
-        <div style="color: !important;">Test</div>
+        <div style="color: !important;">Test no color</div>
+        <div style="margin: 0px 0px 0px 0 px;">Test invalid margin</div>
       </body></html>
     END_HTML
 


### PR DESCRIPTION
Have been suffering from some errors generating within `RuleSets.expand_shorthand!` with invalid CSS such as `margin: 0px 0px 0px 0 px`. 

I guess these errors should also be handled by the `rule_set_exceptions` config?

Similar to a comment left on an issue before, but I don't think any work was done on it: https://github.com/premailer/premailer/issues/420#issuecomment-1273523818

Example error:
```
ArgumentError: Cannot parse 0px 0px 0px 0 px
    /home/david.weir/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/css_parser-1.14.0/lib/css_parser/rule_set.rb:378:in `block in expand_dimensions_shorthand!'
    /home/david.weir/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/css_parser-1.14.0/lib/css_parser/rule_set.rb:353:in `each'
    /home/david.weir/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/css_parser-1.14.0/lib/css_parser/rule_set.rb:353:in `expand_dimensions_shorthand!'
    /home/david.weir/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/css_parser-1.14.0/lib/css_parser/rule_set.rb:294:in `expand_shorthand!'
    lib/premailer/adapter/nokogiri.rb:76:in `block in to_inline_css'
    /home/david.weir/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/nokogiri-1.14.0-x86_64-linux/lib/nokogiri/xml/node_set.rb:235:in `block in each'
    /home/david.weir/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/nokogiri-1.14.0-x86_64-linux/lib/nokogiri/xml/node_set.rb:234:in `upto'
    /home/david.weir/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/nokogiri-1.14.0-x86_64-linux/lib/nokogiri/xml/node_set.rb:234:in `each'
    lib/premailer/adapter/nokogiri.rb:61:in `to_inline_css'
    test/test_premailer.rb:418:in `test_invalid_css'
```

The outputted html will still use `margin: 0px 0px 0px 0 px`