### PR TITLE
port exception capturing to other adapters

### DIFF
--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -67,13 +67,21 @@ class Premailer
 
           declarations = []
           style.scan(/\[SPEC\=([\d]+)\[(.[^\]\]]*)\]\]/).each do |declaration|
-            rs = CssParser::RuleSet.new(nil, declaration[1].to_s, declaration[0].to_i)
-            declarations << rs
+            begin
+              rs = CssParser::RuleSet.new(nil, declaration[1].to_s, declaration[0].to_i)
+              declarations << rs
+            rescue ArgumentError => e
+              raise e if @options[:rule_set_exceptions]
+            end
           end
 
           # Perform style folding
           merged = CssParser.merge(declarations)
-          merged.expand_shorthand!
+          begin
+            merged.expand_shorthand!
+          rescue ArgumentError => e
+            raise e if @options[:rule_set_exceptions]
+          end
 
           # Duplicate CSS attributes as HTML attributes
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name) && @options[:css_to_attributes]

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -61,13 +61,21 @@ class Premailer
 
           declarations = []
           style.scan(/\[SPEC\=([\d]+)\[(.[^\]\]]*)\]\]/).each do |declaration|
-            rs = CssParser::RuleSet.new(nil, declaration[1].to_s, declaration[0].to_i)
-            declarations << rs
+            begin
+              rs = CssParser::RuleSet.new(nil, declaration[1].to_s, declaration[0].to_i)
+              declarations << rs
+            rescue ArgumentError => e
+              raise e if @options[:rule_set_exceptions]
+            end
           end
 
           # Perform style folding
           merged = CssParser.merge(declarations)
-          merged.expand_shorthand!
+          begin
+            merged.expand_shorthand!
+          rescue ArgumentError => e
+            raise e if @options[:rule_set_exceptions]
+          end
 
           # Duplicate CSS attributes as HTML attributes
           if Premailer::RELATED_ATTRIBUTES.has_key?(el.name) && @options[:css_to_attributes]

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -397,7 +397,7 @@ END_HTML
   end
 
 
-  def test_invalid_css
+  def test_invalid_css_nokogiri
     html = <<-END_HTML
       <html><head> <style type="text/css">
         h1 {
@@ -417,7 +417,7 @@ END_HTML
     pm.to_inline_css
   end
 
-  def test_invalid_shorthand_css
+  def test_invalid_shorthand_css_nokogiri
     html = <<-END_HTML
       <html><head></head><body>
       <div style="margin: 0px 0px 0px 0 px;">Test invalid margin</div>
@@ -430,6 +430,78 @@ END_HTML
     end
 
     pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri, rule_set_exceptions: false)
+    pm.to_inline_css
+  end
+
+  def test_invalid_css_nokogiri_fast
+    html = <<-END_HTML
+      <html><head> <style type="text/css">
+        h1 {
+          color: !important;
+        }
+      </style></head><body>
+        <div style="color: !important;">Test no color</div>
+      </body></html>
+    END_HTML
+
+    assert_raises(ArgumentError) do
+      pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri_fast)
+      pm.to_inline_css
+    end
+
+    pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri_fast, rule_set_exceptions: false)
+    pm.to_inline_css
+  end
+
+  def test_invalid_shorthand_css_nokogiri_fast
+    html = <<-END_HTML
+      <html><head></head><body>
+      <div style="margin: 0px 0px 0px 0 px;">Test invalid margin</div>
+      </body></html>
+    END_HTML
+
+    assert_raises(ArgumentError) do
+      pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri_fast)
+      pm.to_inline_css
+    end
+
+    pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri_fast, rule_set_exceptions: false)
+    pm.to_inline_css
+  end
+
+  def test_invalid_css_nokogumbo
+    html = <<-END_HTML
+      <html><head> <style type="text/css">
+        h1 {
+          color: !important;
+        }
+      </style></head><body>
+        <div style="color: !important;">Test no color</div>
+      </body></html>
+    END_HTML
+
+    assert_raises(ArgumentError) do
+      pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogumbo)
+      pm.to_inline_css
+    end
+
+    pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogumbo, rule_set_exceptions: false)
+    pm.to_inline_css
+  end
+
+  def test_invalid_shorthand_css_nokogumbo
+    html = <<-END_HTML
+      <html><head></head><body>
+      <div style="margin: 0px 0px 0px 0 px;">Test invalid margin</div>
+      </body></html>
+    END_HTML
+
+    assert_raises(ArgumentError) do
+      pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogumbo)
+      pm.to_inline_css
+    end
+
+    pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogumbo, rule_set_exceptions: false)
     pm.to_inline_css
   end
 end


### PR DESCRIPTION
Still experiencing some errors in an env I don't have full control over to check, so porting exception capturing other adapters following on from these PRs:

* https://github.com/premailer/premailer/pull/427
* https://github.com/premailer/premailer/pull/421

I think even if it doesn't solve the issue for me it's probably still good hygiene to copy across similar behaviour

## Checklist
- [x] Added tests
- [x] Updated Readme.md (if user facing behavior changed)
- [ ] Updated CHANGELOG.md
