### PR TITLE
Failing test case where Adapter::Nokogiri#to_inline_css raises ArgumentError when rule_set_exceptions: false

### DIFF
--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -65,6 +65,7 @@ class Premailer
           style.scan(/\[SPEC\=([\d]+)\[(.[^\]\]]*)\]\]/).each do |declaration|
             begin
               rs = CssParser::RuleSet.new(nil, declaration[1].to_s, declaration[0].to_i)
+              rs.expand_shorthand! # skip rulesets that will raise in CssParser.merge where they are not rescued
               declarations << rs
             rescue ArgumentError => e
               raise e if @options[:rule_set_exceptions]

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -396,7 +396,6 @@ END_HTML
     $stderr = orig_stderr
   end
 
-
   def test_invalid_css_nokogiri
     html = <<-END_HTML
       <html><head> <style type="text/css">
@@ -405,6 +404,26 @@ END_HTML
         }
       </style></head><body>
         <div style="color: !important;">Test no color</div>
+      </body></html>
+    END_HTML
+
+    assert_raises(ArgumentError) do
+      pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri)
+      pm.to_inline_css
+    end
+
+    pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri, rule_set_exceptions: false)
+    pm.to_inline_css
+  end
+
+  def test_invalid_wildcard_css_in_head_nokogiri
+    html = <<-END_HTML
+      <html><head> <style type="text/css">
+        * {
+          margin:0px 0px 10px ! 0px;
+        }
+      </style></head><body>
+        <div style="margin:0px 0px 10px ! 0px;"></div>
       </body></html>
     END_HTML
 


### PR DESCRIPTION
Currently just a failing test for a form of CSS that is raising an argument error even with `rule_set_exceptions` set to false



## Checklist
- [ ] Added tests
- [ ] Updated Readme.md (if user facing behavior changed)
- [ ] Updated CHANGELOG.md
