### PR TITLE
Drop Ruby 2.7 compatibility

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         task: ["test"]
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '3.0', '3.1', '3.2' ]
     name: ${{ matrix.ruby }} rake ${{ matrix.task }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Premailer CHANGELOG
 
 ### Unreleased
+* Drop Ruby 2.7 compatibility
 
 ### Version 1.22.0
 * Use rule_set_exceptions in for expand_shorthand!

--- a/premailer.gemspec
+++ b/premailer.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new "premailer", Premailer::VERSION do |s|
   s.author  = "Alex Dunae"
   s.files            = `git ls-files lib misc LICENSE.md README.md`.split("\n")
   s.executables      = ['premailer']
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.0'
   s.metadata["yard.run"] = "yri" # use "yard" to build full HTML docs.
   s.metadata['rubygems_mfa_required'] = 'true'
 


### PR DESCRIPTION
Ruby 2.7 reached EOL in March '23. This commit will allow to bump up the minimum required Nokogiri version to 1.16

Ref: #443

Thank you for your contribution!

## Checklist
- [x] ~Added tests~
- [x] ~Updated Readme.md (if user facing behavior changed)~
- [x] Updated CHANGELOG.md
