### PR TITLE
Require Nokogiri >= 1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Drop Ruby 2.7 compatibility
+* Require Nokogiri >= 1.16
 
 ### Version 1.22.0
 * Use rule_set_exceptions in for expand_shorthand!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,14 +35,14 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.8.5)
     minitest (5.17.0)
-    nokogiri (1.15.5)
+    nokogiri (1.16.0)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.15.5-aarch64-linux)
+    nokogiri (1.16.0-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.15.5-java)
+    nokogiri (1.16.0-java)
       racc (~> 1.4)
-    nokogiri (1.15.5-x86_64-linux)
+    nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -87,7 +87,7 @@ DEPENDENCIES
   coveralls
   jruby-openssl
   maxitest
-  nokogiri (~> 1.13)
+  nokogiri (~> 1.16)
   premailer!
   pry
   rake (> 0.8, != 0.9.0)
@@ -95,4 +95,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.12
+   2.5.4

--- a/premailer.gemspec
+++ b/premailer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new "premailer", Premailer::VERSION do |s|
   s.add_runtime_dependency 'addressable'
   s.add_development_dependency "bundler", ">= 1.3"
   s.add_development_dependency 'rake', ['> 0.8',  '!= 0.9.0']
-  s.add_development_dependency 'nokogiri', '~> 1.13'
+  s.add_development_dependency 'nokogiri', '~> 1.16'
   s.add_development_dependency 'redcarpet', '~> 3.0'
   s.add_development_dependency 'maxitest'
   s.add_development_dependency 'coveralls'

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -3,18 +3,19 @@ require File.expand_path(File.dirname(__FILE__)) + '/helper'
 class TestPremailer < Premailer::TestCase
   def test_special_characters_nokogiri
     # Force encoding to ISO-8859 because strings are encoded to UTF-8 by default.
-    # This allows the Nokogiri adapter to use html entities, like `&eacute;`
-    # instead of `é` (`\xe9`).
+    # After some recent changes in libxml2 bundled by Nokogiri, some html
+    # entities will be rendered as their ISO-8859-1 representation
     html = "<p>c\xe9dille c&eacute; & gar\xe7on gar&#231;on \xe0 &agrave; &nbsp; &amp; &copy;</p>".dup.force_encoding('iso-8859-1')
     premailer = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri)
     premailer.to_inline_css
-    assert_equal 'c&eacute;dille c&eacute; &amp; gar&ccedil;on gar&ccedil;on &agrave; &agrave; &nbsp; &amp; &copy;', premailer.processed_doc.at('p').inner_html
+    assert_equal "c\xE9dille c\xE9 &amp; gar\xE7on gar\xE7on \xE0 \xE0 \xA0 &amp; \xA9".dup.force_encoding('iso-8859-1'), premailer.processed_doc.at('p').inner_html
   end
 
   def test_special_characters_nokogiri_remote
     remote_setup('chars.html', :adapter => :nokogiri)
     @premailer.to_inline_css
-    assert_equal 'c&eacute;dille c&eacute; &amp; gar&ccedil;on gar&ccedil;on &agrave; &agrave; &nbsp; &amp; &copy;', @premailer.processed_doc.at('p').inner_html
+    # Force encoding to ISO-8859 because strings are encoded to UTF-8 by default.
+    assert_equal "c\xE9dille c\xE9 &amp; gar\xE7on gar\xE7on \xE0 \xE0 \xA0 &amp; \xA9".dup.force_encoding('iso-8859-1'), @premailer.processed_doc.at('p').inner_html
   end
 
   def test_utf8_encoding


### PR DESCRIPTION
There have been two recent changes in libxml2 2.11 and than 2.12 which broke two specs related to the conversion of UTF-8 chars.

This commit sets the minimum required Nokogiri version to 1.16 which bundles libxml2 2.12, in order to have a predictable behaviour.

References:
- #430
- sparklemotion/nokogiri#2965
- sparklemotion/nokogiri#3032
- GNOME/libxml2@f1c1f5c
- GNOME/libxml2@37cedc0

Close #443

Thank you for your contribution!

## Checklist
- [x] Added tests
- [x] ~Updated Readme.md (if user facing behavior changed)~
- [x] Updated CHANGELOG.md
