### PR TITLE
Add support for no-comma RGB functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Drop Ruby 2.7 compatibility
 * Require Nokogiri >= 1.16
+* Add support for no-comma rgb() functions when `rgb_to_hex_attributes: true`
 
 ### Version 1.22.0
 * Use rule_set_exceptions in for expand_shorthand!

--- a/lib/premailer/adapter/rgb_to_hex.rb
+++ b/lib/premailer/adapter/rgb_to_hex.rb
@@ -9,13 +9,14 @@ module AdapterHelper
     def is_rgb?(color)
       pattern = %r{
       rgb
-      \(\s*    # literal open, with optional whitespace
-      (\d{1,3})   # capture 1-3 digits
-      \s*,\s*     # comma, with optional whitespace
-      (\d{1,3})   # capture 1-3 digits
-      \s*,\s*     # comma, with optional whitespace
-      (\d{1,3})   # capture 1-3 digits
-      \s*\)       # literal close, with optional whitespace
+      \(\s*                    # literal open, with optional whitespace
+      (\d{1,3})                # capture 1-3 digits
+      (?:\s*,\s*|\s+)          # comma or whitespace
+      (\d{1,3})                # capture 1-3 digits
+      (?:\s*,\s*|\s+)          # comma or whitespacee
+      (\d{1,3})                # capture 1-3 digits
+      \s*(?:\/\s*\d*\.?\d*%?)? # optional alpha modifier
+      \s*\)                    # literal close, with optional whitespace
       }x
 
       pattern.match(color)

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -306,7 +306,48 @@ END_HTML
     pm.to_inline_css
     doc = pm.processed_doc
     assert_equal 'FAFAFA', doc.at('table')['bgcolor']
+  end
 
+  def test_rgb_color_without_commas_and_with_alpha_modifier
+    html = <<-END_HTML
+    <html> <head> <style>table { background-color: rgb(250 250 250 / 1); } </style>
+    <body>
+    <table> <tr> <td> Test </td> </tr> </table>
+    </body> </html>
+    END_HTML
+
+    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex_attributes => true, :remove_scripts => true, :adapter => :nokogiri)
+    pm.to_inline_css
+    doc = pm.processed_doc
+    assert_equal 'FAFAFA', doc.at('table')['bgcolor']
+  end
+
+  def test_rgb_color_without_commas_and_with_percentage_modifier
+    html = <<-END_HTML
+    <html> <head> <style>table { background-color: rgb(250 250 250 / 15%); } </style>
+    <body>
+    <table> <tr> <td> Test </td> </tr> </table>
+    </body> </html>
+    END_HTML
+
+    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex_attributes => true, :remove_scripts => true, :adapter => :nokogiri)
+    pm.to_inline_css
+    doc = pm.processed_doc
+    assert_equal 'FAFAFA', doc.at('table')['bgcolor']
+  end
+
+  def test_rgb_color_is_not_matched_without_three_color_arguments
+    html = <<-END_HTML
+    <html> <head> <style>table { background-color: rgb(111 222 / 1); } </style>
+    <body>
+    <table> <tr> <td> Test </td> </tr> </table>
+    </body> </html>
+    END_HTML
+
+    pm = Premailer.new(html, :with_html_string => true, :rgb_to_hex_attributes => true, :remove_scripts => true, :adapter => :nokogiri)
+    pm.to_inline_css
+    doc = pm.processed_doc
+    assert_equal 'rgb(111 222 / 1)', doc.at('table')['bgcolor']
   end
 
   def test_non_rgb_color


### PR DESCRIPTION
This commit adds support for converting rgb with alpha modifiers (e.g. `rgb(1 2 3 / 0.5)`) to hex, which are featured prominently in Tailwind (to the point that even turning them off doesn't seem to fully turn them off)

More info on these:
https://css-tricks.com/no-comma-color-functions-in-css/

## Checklist
- [x] Added tests
- [x] Updated Readme.md (if user facing behavior changed)
- [x] Updated CHANGELOG.md
