### PR TITLE
Prepares for all strings to be frozen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Premailer CHANGELOG
 
 ### Unreleased
+* Removes frozen string errors with RUBYOPT="--enable-frozen-string-literal"
 
 ### Version 1.23.0
 * Drop Ruby 2.7 compatibility

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -235,6 +235,7 @@ class Premailer
 
         # Handle HTML entities
         if @options[:replace_html_entities] == true and thing.is_a?(String)
+          thing = +thing
           HTML_ENTITIES.map do |entity, replacement|
             thing.gsub! entity, replacement
           end

--- a/lib/premailer/html_to_plain_text.rb
+++ b/lib/premailer/html_to_plain_text.rb
@@ -14,7 +14,7 @@ module HtmlToPlainText
   # TODO: add support for DL, OL
   # TODO: this is not safe and needs a real html parser to work
   def convert_to_text(html, line_length = 65, from_charset = 'UTF-8')
-    txt = html
+    txt = +html
 
     # strip text ignored html. Useful for removing
     # headers and footers that aren't needed in the

--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -264,7 +264,7 @@ class Premailer
 
 protected
   def load_css_from_local_file!(path)
-    css_block = ''
+    css_block = +''
     path.gsub!(/\Afile:/, '')
     begin
       File.open(path, "r") do |file|
@@ -358,6 +358,7 @@ public
   def append_query_string(doc, qs)
     return doc if qs.nil?
 
+    qs = +qs
     qs.to_s.gsub!(/^[\?]*/, '').strip!
     return doc if qs.empty?
 
@@ -473,6 +474,7 @@ public
 
   # @private
   def self.resolve_link(path, base_path) # :nodoc:
+    path = +path
     path.strip!
     resolved = nil
     if path =~ /\A(?:(https?|ftp|file):)\/\//i


### PR DESCRIPTION
There was a deprecation warning for chilled strings merged recently in Ruby: https://github.com/ruby/ruby/commit/12be40ae6be78ac41e8e3f3c313cc6f63e7fa6c4

And with that we started to see the following warning coming from `premailer`:

```
vendor/gems/3.4.0/ruby/3.4.0+0/gems/premailer-1.13.1/lib/premailer/premailer.rb:269: warning: literal string will be frozen in the future
```

These changes remove those errors by unfreezing strings when they should be mutable. They get the test suite to pass with RUBYOPT="--enable-frozen-string-literal", which will be the default in the future.

## Checklist
- [ ] Added tests
- [ ] Updated Readme.md (if user facing behavior changed)
- [x] Updated CHANGELOG.md
