### PR TITLE
Pins css_parser version to below 1.17.1 to avoid deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Premailer CHANGELOG
 
 ### Unreleased
+* Pins css_parser version to below 1.17.1 to avoid deprecation
 
 ### Version 1.24.0
 * Removes frozen string errors with RUBYOPT="--enable-frozen-string-literal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     premailer (1.25.0)
       addressable
-      css_parser (>= 1.12.0)
+      css_parser (>= 1.12.0, <= 1.17.1)
       htmlentities (>= 4.0.0)
 
 GEM

--- a/premailer.gemspec
+++ b/premailer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new "premailer", Premailer::VERSION do |s|
   s.metadata["yard.run"] = "yri" # use "yard" to build full HTML docs.
   s.metadata['rubygems_mfa_required'] = 'true'
 
-  s.add_runtime_dependency 'css_parser', '>= 1.12.0'
+  s.add_runtime_dependency 'css_parser', ['>= 1.12.0', '<= 1.17.1']
   s.add_runtime_dependency 'htmlentities', ['>= 4.0.0']
   s.add_runtime_dependency 'addressable'
   s.add_development_dependency "bundler", ">= 1.3"


### PR DESCRIPTION
When upgrading ruby dependencies I received a deprecation warning:
`warning: [DEPRECATION] positional arguments are deprecated use keyword instead`

This is due to `css_parser` > 1.17.1 deprecating positional arguments. I've pinned the version to below 1.17.1 so they can avoid deprecation warnings until this is fixed. 

## Checklist
- [ x ] Updated Readme.md (if user facing behavior changed)
- [ x ] Updated CHANGELOG.md
