### PR TITLE
Support CSS variables in Premailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+### Version 1.27.1
+* Support and interpolate CSS variables from loaded stylesheets
+
 ### Version 1.27.0
 * Support multiline inline styles [issue](https://github.com/premailer/premailer/issues/458)
 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ See .github/workflows/actions.yml for which ruby versions are tested. JRuby supp
 
 Premailer looks for a few CSS attributes that make working with tables a bit easier.
 
-| CSS Attribute | Availability |
-| ------------- | ------------ |
-| -premailer-width | Available on `table`, `th` and `td` elements |
-| -premailer-height | Available on `table`, `tr`, `th` and `td` elements |
-| -premailer-cellpadding | Available on `table` elements |
-| -premailer-cellspacing | Available on `table` elements |
-| -premailer-align | Available on `table` elements |
+| CSS Attribute           | Availability                                                                             |
+| ----------------------- | ---------------------------------------------------------------------------------------- |
+| -premailer-width        | Available on `table`, `th` and `td` elements                                             |
+| -premailer-height       | Available on `table`, `tr`, `th` and `td` elements                                       |
+| -premailer-cellpadding  | Available on `table` elements                                                            |
+| -premailer-cellspacing  | Available on `table` elements                                                            |
+| -premailer-align        | Available on `table` elements                                                            |
 | data-premailer="ignore" | Available on `link` and `style` elements. Premailer will ignore these elements entirely. |
 
 Each of these CSS declarations will be copied to appropriate element's attribute.
@@ -127,6 +127,30 @@ Premailer.new(
 
 [available options](https://premailer.github.io/premailer/Premailer.html#initialize-instance_method)
 
+## CSS Variables
+
+If you make use of CSS variables in your emails, Premailer will interpolate any CSS variables
+defined in `:root` and interpolate them into the inline styles. For example:
+
+```
+<html>
+   <body>
+      <style type="text/css"> :root { --red: #f00; --yellow: #ff0; } </style>
+      <style type="text/css"> p { color: var(--red); border: 1px solid var(--yellow); } </style>
+      <p>Test</p>
+   </body>
+</html>
+```
+
+...will result in the following inline styles:
+
+```
+<html>
+   <body>
+      <p style="color: #f00; border: 1px solid #ff0;">Test</p>
+   </body>
+</html>
+```
 
 ## Contributions
 

--- a/lib/premailer.rb
+++ b/lib/premailer.rb
@@ -8,6 +8,7 @@ require 'css_parser'
 
 require 'premailer/adapter'
 require 'premailer/adapter/rgb_to_hex'
+require 'premailer/adapter/variables'
 require 'premailer/html_to_plain_text'
 require 'premailer/premailer'
 require 'premailer/cached_rule_set'

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -264,21 +264,6 @@ class Premailer
 
         doc
       end
-
-      private
-
-      def css_variables
-        @css_variables ||= @css_parser.find_by_selector(":root").reduce({}) do |memo, rule|
-          rules = rule.split(";")
-          rules.each do |rule|
-            rule = rule.strip
-            if match = rule.match(/--([^:]+):(.+)/)
-              memo[match[1].strip] = match[2].strip
-            end
-          end
-          memo
-        end
-      end
     end
   end
 end

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -8,6 +8,8 @@ class Premailer
       WIDTH_AND_HEIGHT = ['width', 'height'].freeze
 
       include AdapterHelper::RgbToHex
+      include AdapterHelper::Variables
+
       # Merge CSS into the HTML document.
       #
       # @return [String] an HTML.

--- a/lib/premailer/adapter/nokogiri_fast.rb
+++ b/lib/premailer/adapter/nokogiri_fast.rb
@@ -29,6 +29,9 @@ class Premailer
 
         # Iterate through the rules and merge them into the HTML
         @css_parser.each_selector(:all) do |selector, declaration, specificity, media_types|
+          # Replace declarations referencing CSS variables with their parsed values
+          declaration = map_variables(declaration)
+
           # Save un-mergable rules separately
           selector.gsub!(/:link([\s]*)+/i) { |_m| $1 }
 

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -22,6 +22,9 @@ class Premailer
         end
         # Iterate through the rules and merge them into the HTML
         @css_parser.each_selector(:all) do |selector, declaration, specificity, media_types|
+          # Replace declarations referencing CSS variables with their parsed values
+          declaration = map_variables(declaration)
+
           # Save un-mergable rules separately
           selector.gsub!(/:link([\s]*)+/i) { |_m| $1 }
 

--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -6,6 +6,8 @@ class Premailer
       WIDTH_AND_HEIGHT = ['width', 'height'].freeze
 
       include AdapterHelper::RgbToHex
+      include AdapterHelper::Variables
+
       # Merge CSS into the HTML document.
       #
       # @return [String] an HTML.

--- a/lib/premailer/adapter/variables.rb
+++ b/lib/premailer/adapter/variables.rb
@@ -24,7 +24,7 @@ module AdapterHelper
     private
 
     def css_variables
-      root_variables = @css_parser.find_by_selector(":root").reduce({}) do |memo, rule|
+      @css_variables ||= @css_parser.find_by_selector(":root").reduce({}) do |memo, rule|
         rules = rule.split(";")
         rules.each do |rule|
           rule = rule.strip

--- a/lib/premailer/adapter/variables.rb
+++ b/lib/premailer/adapter/variables.rb
@@ -1,14 +1,18 @@
+# frozen_string_literal: true
+
 module AdapterHelper
   module Variables
     def map_variables(declaration)
-      while declaration.match?(/var\(\s*--([^)]+)\s*\)/)
+      while declaration.match?(/\bvar\(\s*--([^)]+)\s*\)/)
         final_declarations = []
         declarations = declaration.split(";").map(&:strip).reject(&:empty?)
         declarations.each do |declaration|
-          if match = declaration.match(/\bvar\(\s*--([^)]+)\s*\)/)
+          match = declaration.match(/\bvar\(\s*--([^)]+)\s*\)/)
+          if match
             variable = match[0]
             variable_name = match[1]
-            if variable_value = css_variables[variable_name]
+            variable_value = css_variables[variable_name]
+            unless variable_value.empty?
               final_declarations.push(declaration.gsub(variable, variable_value))
             end
           else
@@ -24,15 +28,15 @@ module AdapterHelper
     private
 
     def css_variables
-      @css_variables ||= @css_parser.find_by_selector(":root").reduce({}) do |memo, rule|
-        rules = rule.split(";")
+      @css_variables ||= @css_parser.find_by_selector(":root").each_with_object({}) do |ruleset, memo|
+        rules = ruleset.split(";")
         rules.each do |rule|
           rule = rule.strip
-          if match = rule.match(/--([^:]+):(.+)/)
+          match = rule.match(/--([^:]+):(.+)/)
+          if match
             memo[match[1].strip] = match[2].strip
           end
         end
-        memo
       end
     end
   end

--- a/lib/premailer/adapter/variables.rb
+++ b/lib/premailer/adapter/variables.rb
@@ -1,0 +1,39 @@
+module AdapterHelper
+  module Variables
+    def map_variables(declaration)
+      while declaration.match?(/var\(\s*--([^)]+)\s*\)/)
+        final_declarations = []
+        declarations = declaration.split(";").map(&:strip).reject(&:empty?)
+        declarations.each do |declaration|
+          if match = declaration.match(/\bvar\(\s*--([^)]+)\s*\)/)
+            variable = match[0]
+            variable_name = match[1]
+            if variable_value = css_variables[variable_name]
+              final_declarations.push(declaration.gsub(variable, variable_value))
+            end
+          else
+            final_declarations.push(declaration)
+          end
+        end
+        declaration = final_declarations.join(";")
+      end
+
+      declaration
+    end
+
+    private
+
+    def css_variables
+      root_variables = @css_parser.find_by_selector(":root").reduce({}) do |memo, rule|
+        rules = rule.split(";")
+        rules.each do |rule|
+          rule = rule.strip
+          if match = rule.match(/--([^:]+):(.+)/)
+            memo[match[1].strip] = match[2].strip
+          end
+        end
+        memo
+      end
+    end
+  end
+end

--- a/test/test_css_variables.rb
+++ b/test/test_css_variables.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require __dir__ + '/helper'
+
+class TestCssVariables < Premailer::TestCase
+  [:nokogiri, :nokogumbo, :nokogiri_fast].each do |adapter|
+    class_eval <<~RUBY, __FILE__, __LINE__ + 1
+      # Test that CSS variables are inlined correctly with the #{adapter} adapter
+      def test_css_variables_in_#{adapter}
+        html = <<~END_HTML
+          <html>
+          <body>
+          <style type="text/css"> :root { --red: #f00; --yellow: #ff0; } </style>
+          <style type="text/css"> p { color: var(--red); border: 1px solid var(--yellow); } </style>
+          <p>Test</p>
+          </body>
+          </html>
+        END_HTML
+
+        premailer = Premailer.new(html, :adapter => :#{adapter}, :with_html_string => true)
+        premailer.to_inline_css
+
+        assert_match /color:\s*#f00/i, premailer.processed_doc.at('p')['style']
+        assert_match /border:\s*1px solid #ff0/i, premailer.processed_doc.at('p')['style']
+      end
+    RUBY
+  end
+end

--- a/test/test_css_variables.rb
+++ b/test/test_css_variables.rb
@@ -2,26 +2,27 @@
 require __dir__ + '/helper'
 
 class TestCssVariables < Premailer::TestCase
-  [:nokogiri, :nokogumbo, :nokogiri_fast].each do |adapter|
-    class_eval <<~RUBY, __FILE__, __LINE__ + 1
-      # Test that CSS variables are inlined correctly with the #{adapter} adapter
-      def test_css_variables_in_#{adapter}
-        html = <<~END_HTML
-          <html>
-          <body>
-          <style type="text/css"> :root { --red: #f00; --yellow: #ff0; } </style>
-          <style type="text/css"> p { color: var(--red); border: 1px solid var(--yellow); } </style>
-          <p>Test</p>
-          </body>
-          </html>
-        END_HTML
+  def test_css_variables
+    html = <<~END_HTML
+      <html>
+      <body>
+      <style type="text/css"> :root { --red: #f00; --yellow: #ff0; } </style>
+      <style type="text/css"> p { color: var(--red); border: 1px solid var(--yellow); } </style>
+      <p>Test</p>
+      </body>
+      </html>
+    END_HTML
 
-        premailer = Premailer.new(html, :adapter => :#{adapter}, :with_html_string => true)
-        premailer.to_inline_css
+    color_regex = /color:\s*#f00/i
+    border_regex = /border:\s*1px solid #ff0/i
 
-        assert_match /color:\s*#f00/i, premailer.processed_doc.at('p')['style']
-        assert_match /border:\s*1px solid #ff0/i, premailer.processed_doc.at('p')['style']
-      end
-    RUBY
+    [:nokogiri, :nokogumbo, :nokogiri_fast].each do |adapter|
+      premailer = Premailer.new(html, :adapter => adapter, :with_html_string => true)
+      premailer.to_inline_css
+      styles = premailer.processed_doc.at('p')['style']
+
+      assert_match(color_regex, styles, "Using adapter :#{adapter}")
+      assert_match(border_regex, styles, "Using adapter :#{adapter}")
+    end
   end
 end


### PR DESCRIPTION
This PR adds support for CSS variables defined in a `:root` block in any of the styles. This will ensure CSS variables are correctly inserted into the generated inline styles!

## Checklist
- [X] Added tests
- [X] Updated Readme.md (if user facing behavior changed)
- [X] Updated CHANGELOG.md

