### PR TITLE
Nil @html_file and auxiliary ivars in cleanup!

### DIFF
--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -360,6 +360,9 @@ class Premailer
     @processed_doc = nil
     @css_parser = nil
     @unmergable_rules = nil
+    @html_file = nil
+    @css_warnings = nil
+    @css_files = nil
   end
 
   # @private

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -583,6 +583,9 @@ END_HTML
       assert_nil pm.doc, "Using: #{adapter}"
       assert_nil pm.processed_doc, "Using: #{adapter}"
       assert_nil pm.unmergable_rules, "Using: #{adapter}"
+      assert_nil pm.instance_variable_get(:@html_file), "Using: #{adapter}"
+      assert_nil pm.instance_variable_get(:@css_warnings), "Using: #{adapter}"
+      assert_nil pm.instance_variable_get(:@css_files), "Using: #{adapter}"
       assert_match /test/, result, "Using: #{adapter}"
     end
   end


### PR DESCRIPTION
## Summary

`cleanup!` already nils `@doc`, `@processed_doc`, `@css_parser`, and `@unmergable_rules`, but leaves `@html_file` (the full input HTML string), `@css_warnings`, and `@css_files` alive. In high-throughput scenarios (e.g. Sidekiq email workers processing concurrent jobs) these references keep large strings allocated longer than necessary.

This PR nils them alongside the other ivars so GC can reclaim the memory sooner.

## Context

We use Premailer in a Sidekiq service that renders ~millions of email receipts/day. After adding `cleanup!` (thanks for merging #472!), we instrumented our workers with per-GC-cycle object counting and RSS tracking. The data showed that while `cleanup!` correctly frees the Nokogiri documents, the original HTML string passed to `Premailer.new` (`@html_file`) — which for rendered email templates can be 50-100KB — stays alive until the Premailer instance itself is collected.

In a multi-threaded Sidekiq environment with 10+ concurrent threads, that's potentially 1MB+ of unnecessary string retention per worker process.