### PR TITLE
Rewrite to_inline_css fold pipeline in Nokogiri adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Premailer CHANGELOG
 
 ### Unreleased
+* Nokogiri adapter: track matched rules per node instead of `[SPEC=n[...]]` style-attribute markers and cache style folding per unique rule combination — 5-6x faster `to_inline_css` on large documents with identical output. Elements whose only matched rule has an invalid declaration now keep `style=""` (matching marker behavior) when `rule_set_exceptions` is disabled.
 
 ### Version 1.28.0
 * drop EOL rubies

--- a/lib/premailer/adapter/nokogiri.rb
+++ b/lib/premailer/adapter/nokogiri.rb
@@ -15,10 +15,21 @@ class Premailer
         doc = @processed_doc
         @unmergable_rules = CssParser::Parser.new
 
+        # Accumulate matched rule sets per node in memory instead of
+        # round-tripping them through style attributes as [SPEC=n[...]]
+        # string markers (which costs two libxml2 attribute round-trips per
+        # element plus a regex re-scan, and dominates allocation churn).
+        rules_by_node = {}
+
         # Give all styles already in style attributes a specificity of 1000
         # per http://www.w3.org/TR/CSS21/cascade.html#specificity
+        # Identical style strings (repeated components) share one rule set so
+        # the fold cache below can hit on them.
+        rule_set_cache = {}
         doc.search("*[@style]").each do |el|
-          el['style'] = '[SPEC=1000[' + el.attributes['style'] + ']]'
+          style = el.attributes['style'].to_s
+          rs = rule_set_cache.fetch(style) { rule_set_cache[style] = build_rule_set(style, 1000) }
+          rules_by_node[el] = rs ? [rs] : []
         end
         # Iterate through the rules and merge them into the HTML
         @css_parser.each_selector(:all) do |selector, declaration, specificity, media_types|
@@ -42,11 +53,25 @@ class Premailer
               # than one element.  Added to work around dodgy generated code.
               selector.gsub!(/\A\#([\w_\-]+)\Z/, '*[@id=\1]')
 
+              rule_set = nil
+              rule_set_missing = false
               doc.search(selector).each do |el|
                 if el.elem? && ((el.name != 'head') && (el.parent.name != 'head'))
-                  # Add a style attribute or append to the existing one
-                  block = "[SPEC=#{specificity}[#{declaration}]]"
-                  el['style'] = (el.attributes['style'].to_s ||= '') + ' ' + block
+                  # Enroll the element even when the rule below fails to build:
+                  # the marker implementation wrote the style attribute before
+                  # parsing, so matched elements end up with style="" when
+                  # their only rule is invalid and exceptions are disabled.
+                  rules = (rules_by_node[el] ||= [])
+                  next if rule_set_missing
+
+                  # One shared rule set per CSS rule; merge never mutates inputs
+                  # (CachedRuleSet#expand_shorthand! is idempotent by design).
+                  rule_set ||= build_rule_set(declaration, specificity)
+                  if rule_set.nil?
+                    rule_set_missing = true
+                    next
+                  end
+                  rules << rule_set
                 end
               end
             rescue ::Nokogiri::SyntaxError, RuntimeError, ArgumentError
@@ -59,60 +84,28 @@ class Premailer
         # Remove script tags
         doc.search("script").remove if @options[:remove_scripts]
 
-        # Read STYLE attributes and perform folding
-        doc.search("*[@style]").each do |el|
-          style = el.attributes['style'].to_s
+        # Perform style folding. Elements sharing the same matched rule sets
+        # (ubiquitous in table-based email markup) fold to the same result, so
+        # the merge/expand/collapse/serialize pipeline runs once per unique
+        # (element name, rule list) pair instead of once per element.
+        fold_cache = {}
+        rules_by_node.each do |el, declarations|
+          related = Premailer::RELATED_ATTRIBUTES.key?(el.name) && @options[:css_to_attributes]
+          # Rule sets are interned above, so default identity hashing makes
+          # them usable directly as cache key elements.
+          cache_key = [related ? el.name : nil, *declarations]
 
-          declarations = style.scan(/\[SPEC=([\d]+)\[(.[^\]]*)\]\]/m).filter_map do |declaration|
-            rs = Premailer::CachedRuleSet.new(block: declaration[1].to_s, specificity: declaration[0].to_i)
-            rs.expand_shorthand!
-            rs
-          rescue ArgumentError => e
-            raise e if @options[:rule_set_exceptions]
+          folded = fold_cache[cache_key] ||= fold_declarations(declarations, related ? el.name : nil)
+          style, attributes = folded
+
+          # Write the inline STYLE attribute first so the attribute order for
+          # elements that had no style attribute matches the marker-based
+          # implementation (style attr was created during selector matching).
+          el['style'] = style
+
+          attributes&.each do |html_attr, value|
+            el[html_attr] = value if el[html_attr].nil?
           end
-
-          # Perform style folding
-          merged = CssParser.merge(declarations)
-          begin
-            merged.expand_shorthand!
-          rescue ArgumentError => e
-            raise e if @options[:rule_set_exceptions]
-          end
-
-          # Duplicate CSS attributes as HTML attributes
-          if Premailer::RELATED_ATTRIBUTES.key?(el.name) && @options[:css_to_attributes]
-            Premailer::RELATED_ATTRIBUTES[el.name].each do |css_attr, html_attr|
-              if el[html_attr].nil? && !merged[css_attr].empty?
-                new_val = merged[css_attr].dup
-
-                # Remove url() function wrapper
-                new_val.gsub!(/url\((['"])(.*?)\1\)/, '\2')
-
-                # Remove !important, trailing semi-colon, and leading/trailing whitespace
-                new_val.gsub!(/;$|\s*!important/, '').strip!
-
-                # For width and height tags, remove px units
-                new_val.gsub!(/(\d+)px/, '\1') if WIDTH_AND_HIGHT.include?(html_attr)
-
-                # For color-related tags, convert RGB to hex if specified by options
-                new_val = ensure_hex(new_val) if css_attr.end_with?('color') && @options[:rgb_to_hex_attributes]
-
-                el[html_attr] = new_val
-              end
-
-              unless @options[:preserve_style_attribute]
-                merged.instance_variable_get(:@declarations).tap do |declarations|
-                  declarations.delete(css_attr)
-                end
-              end
-            end
-          end
-
-          # Collapse multiple rules into one as much as possible.
-          merged.create_shorthand! if @options[:create_shorthands]
-
-          # write the inline STYLE attribute
-          el['style'] = merged.declarations_to_s
         end
 
         doc = write_unmergable_css_rules(doc, @unmergable_rules) unless @options[:drop_unmergeable_css_rules]
@@ -159,6 +152,72 @@ class Premailer
         else
           @processed_doc.to_html(:encoding => @options[:output_encoding])
         end
+      end
+
+      # Merge a list of rule sets into a final style string plus the HTML
+      # attribute duplications (bgcolor/align/...) for RELATED_ATTRIBUTES
+      # elements. Element-independent: the per-element "attribute already
+      # set" guard stays with the caller.
+      def fold_declarations(declarations, related_el_name) # :nodoc:
+        merged = CssParser.merge(declarations)
+        if merged.equal?(declarations[0])
+          # CssParser.merge returns its input untouched when given a single
+          # rule set; copy it before the destructive fold pipeline below so
+          # rule sets shared across elements are not corrupted.
+          merged = CssParser::RuleSet.new(block: merged.declarations_to_s, specificity: merged.specificity)
+        end
+        begin
+          merged.expand_shorthand!
+        rescue ArgumentError => e
+          raise e if @options[:rule_set_exceptions]
+        end
+
+        attributes = nil
+        # Duplicate CSS attributes as HTML attributes
+        if related_el_name
+          Premailer::RELATED_ATTRIBUTES[related_el_name].each do |css_attr, html_attr|
+            unless merged[css_attr].empty?
+              new_val = merged[css_attr].dup
+
+              # Remove url() function wrapper
+              new_val.gsub!(/url\((['"])(.*?)\1\)/, '\2')
+
+              # Remove !important, trailing semi-colon, and leading/trailing whitespace
+              new_val.gsub!(/;$|\s*!important/, '').strip!
+
+              # For width and height tags, remove px units
+              new_val.gsub!(/(\d+)px/, '\1') if WIDTH_AND_HIGHT.include?(html_attr)
+
+              # For color-related tags, convert RGB to hex if specified by options
+              new_val = ensure_hex(new_val) if css_attr.end_with?('color') && @options[:rgb_to_hex_attributes]
+
+              (attributes ||= []) << [html_attr, new_val]
+            end
+
+            unless @options[:preserve_style_attribute]
+              merged.instance_variable_get(:@declarations).tap do |declarations|
+                declarations.delete(css_attr)
+              end
+            end
+          end
+        end
+
+        # Collapse multiple rules into one as much as possible.
+        merged.create_shorthand! if @options[:create_shorthands]
+
+        # write the inline STYLE attribute
+        [merged.declarations_to_s, attributes]
+      end
+
+      # Build an expanded rule set for folding. Returns nil (and optionally
+      # swallows the error, mirroring the old fold-time rescue) on bad CSS.
+      def build_rule_set(block, specificity) # :nodoc:
+        rs = Premailer::CachedRuleSet.new(block: block, specificity: specificity)
+        rs.expand_shorthand!
+        rs
+      rescue ArgumentError => e
+        raise e if @options[:rule_set_exceptions]
+        nil
       end
 
       # Create a <tt>style</tt> element with un-mergable rules (e.g. <tt>:hover</tt>)

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -434,4 +434,89 @@ END_HTML
       assert_equal 'color: red; padding: 10px 12px;', doc.at('div').attributes['style'].to_s
     end
   end
+
+  def test_folding_shared_rules_does_not_corrupt_them
+    html = <<-END_HTML
+      <html><head><style>
+        td { background-color: #fff; }
+        .x { color: red; }
+      </style></head><body>
+      <table><tr>
+        <td>one</td>
+        <td class="x">two</td>
+      </tr></table>
+      </body></html>
+    END_HTML
+
+    [:nokogiri, :nokogiri_fast, :nokogumbo].each do |adapter|
+      premailer = Premailer.new(html, :with_html_string => true, :adapter => adapter)
+      premailer.to_inline_css
+      tds = premailer.processed_doc.search('td')
+      assert_equal '#fff', tds[0]['bgcolor'], "Using: #{adapter}"
+      assert_equal '#fff', tds[1]['bgcolor'], "Using: #{adapter}"
+      assert_equal 'color: red;', tds[1]['style'], "Using: #{adapter}"
+    end
+  end
+
+  def test_css_to_attributes_only_applies_to_related_elements
+    html = <<-END_HTML
+      <html><head><style>
+        .x { background-color: #bada55; }
+      </style></head><body>
+      <table><tr><td class="x">cell</td></tr></table>
+      <div class="x">div</div>
+      </body></html>
+    END_HTML
+
+    [:nokogiri, :nokogiri_fast, :nokogumbo].each do |adapter|
+      premailer = Premailer.new(html, :with_html_string => true, :adapter => adapter)
+      premailer.to_inline_css
+      doc = premailer.processed_doc
+      assert_equal '#bada55', doc.at('td')['bgcolor'], "Using: #{adapter}"
+      assert_equal '', doc.at('td')['style'], "Using: #{adapter}"
+      assert_equal 'background-color: #bada55;', doc.at('div')['style'], "Using: #{adapter}"
+      assert_nil doc.at('div')['bgcolor'], "Using: #{adapter}"
+    end
+  end
+
+  def test_css_to_attributes_preserves_existing_html_attributes
+    html = <<-END_HTML
+      <html><head><style>
+        td { background-color: #fff; }
+      </style></head><body>
+      <table><tr>
+        <td>a</td>
+        <td bgcolor="#000">b</td>
+        <td>c</td>
+      </tr></table>
+      </body></html>
+    END_HTML
+
+    [:nokogiri, :nokogiri_fast, :nokogumbo].each do |adapter|
+      premailer = Premailer.new(html, :with_html_string => true, :adapter => adapter)
+      premailer.to_inline_css
+      tds = premailer.processed_doc.search('td')
+      assert_equal ['#fff', '#000', '#fff'], tds.map { |td| td['bgcolor'] }, "Using: #{adapter}"
+      assert_equal ['', '', ''], tds.map { |td| td['style'] }, "Using: #{adapter}"
+    end
+  end
+
+  def test_repeated_identical_style_attributes_fold_identically
+    html = <<-END_HTML
+      <html><head><style>
+        p { padding: 1px; }
+      </style></head><body>
+      <p style="color: green">a</p>
+      <p style="color: green">b</p>
+      </body></html>
+    END_HTML
+
+    expected = ['color: green; padding: 1px;'] * 2
+    [:nokogiri, :nokogiri_fast, :nokogumbo].each do |adapter|
+      premailer = Premailer.new(html, :with_html_string => true, :adapter => adapter)
+      premailer.to_inline_css
+      styles = premailer.processed_doc.search('p').map { |p| p['style'] }
+      assert_equal expected, styles, "Using: #{adapter}"
+    end
+  end
 end

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -574,6 +574,28 @@ END_HTML
     pm.to_inline_css
   end
 
+  # nokogiri_fast and nokogumbo inline raw declaration text at match time and
+  # leave the invalid declaration in the style attribute instead.
+  def test_invalid_declaration_only_match_keeps_empty_style_nokogiri
+    html = <<-END_HTML
+      <html><head> <style type="text/css">
+        p { margin: 0px 0px 0px 0 px; }
+      </style></head><body>
+        <p>one</p>
+        <p>two</p>
+      </body></html>
+    END_HTML
+
+    pm = Premailer.new(html, :with_html_string => true, :adapter => :nokogiri, rule_set_exceptions: false)
+    pm.to_inline_css
+    paragraphs = pm.processed_doc.search('p')
+    assert_equal 2, paragraphs.size
+    paragraphs.each do |p|
+      refute_nil p['style']
+      assert_equal '', p['style']
+    end
+  end
+
   def test_cleanup_frees_memory_and_output_is_usable
     [:nokogiri, :nokogiri_fast, :nokogumbo].each do |adapter|
       pm = Premailer.new('<p>test</p>', :with_html_string => true, :adapter => adapter)


### PR DESCRIPTION
Hello, being transparent this change is AI generated with Fable 5. I've spent time understanding the code changes and feel comfortable with them. I've also empirically tested real-world emails and have confirmed equivalence in all the cases i've checked.

The PR description starts off with the change broken down in my own words. Below that is marked as AI generated.

Happy to discuss this approach with you, i'd even consider making this an alternative adapter if that makes you more comfortable but I believe it's robust enough to replace the default adapter.

## What

Replaces the `[SPEC=n[...]]` string replacement tracking with a hash to track the rules.

Instead of the SPEC string replacements in the doc, we build a map of the style -> `Premailer::CachedRuleSet` this makes `rules_by_node` a map from element -> references of the same `CachedRuleSet` that apply. This is partly responsible for the memory savings by storing references like this as well as deduplicating style rules.

Next for each element matching the css selector we check if we have cached a rule in the above `rules_by_node` map (default to empty list), and we mutate that array by adding the ruleset for the css selector we're on. This rule_set is also cached for the selector as it doesnt change.

Finally the folding, by this time we should have `rules_by_node` being a map from element -> rules (style + any css that applies). If an element can be related (e.g. a `td` vs a `div`) we strongly include the element name in the fold cache along with the ordered list of the declarations that apply. If it's not a related element, then the declarations apply the same and can be cached without the name key for re-use. Then we mutate the element with the updated style and attributes.


Below is AI generated overview

- Matched rule sets accumulate in a `rules_by_node` hash instead of being serialized into each element's `style` attribute and re-parsed with a regex scan (two libxml2 attribute round-trips per element eliminated).
- One shared `CachedRuleSet` per CSS rule and per identical inline style string, instead of a fresh parse per declaration per element.
- The merge/expand/attr-split/shorthand fold is memoized per (element-kind, rule-set list) — table-based email markup repeats the same rule combinations across hundreds of elements, so the fold pipeline runs once per unique combination instead of once per element.
- Copy-on-alias guard: `CssParser.merge` returns its input aliased for single-rule merges, and the fold pipeline mutates its receiver, so shared rule sets are copied before folding.

## Validation (rebased onto master / v1.29.0)

- Full test suite: **110 runs, 499 assertions, 0 failures, 0 errors, 0 skips**

## Performance (p50, ruby 3.4.1 + YJIT, 30 iterations)

| document | `to_inline_css` stock 1.29 | this branch | speedup |
|---|---|---|---|
| 1.1MB email  | 303.98ms | **70.40ms** | **4.3×** |
| 57KB email | 9.17ms | **3.30ms** | **2.8×** |

Original fixture-scale results (v1.27.0 base): base/x6/x11/x21/x41 min ms 3.12/45.7/91.1/180/390 → 2.99/9.3/16.4/30.2/71.2 (5.5–6× at scale); object allocations at x21: 1,199k → 82k. Peak memory on x21: +95.5MB → +1.7MB (56× lower), since rule sets are shared pointers rather than declaration text duplicated into every element's style attribute.


## Checklist
- [X] Added tests
- [N/A] Updated Readme.md (if user facing behavior changed)
- [N/A] Updated CHANGELOG.md
